### PR TITLE
feat: Validate auth chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "auth-server",
       "dependencies": {
+        "@dcl/crypto": "^3.4.5",
         "@dcl/schemas": "^9.6.0",
         "@well-known-components/env-config-provider": "^1.2.0",
         "@well-known-components/http-requests-logger-component": "^2.1.0",
@@ -20,6 +21,7 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "decentraland-crypto-middleware": "^1.1.0",
+        "ethers": "^6.9.1",
         "express": "^4.18.2",
         "socket.io": "^4.7.2",
         "uuid": "^9.0.1"
@@ -43,6 +45,11 @@
         "bufferutil": "^4.0.8",
         "utf-8-validate": "^5.0.10"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -583,6 +590,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@dcl/crypto": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
+      "integrity": "sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==",
+      "dependencies": {
+        "@dcl/schemas": "^9.2.0",
+        "eth-connect": "^6.0.3",
+        "ethereum-cryptography": "^1.0.3"
+      }
+    },
+    "node_modules/@dcl/crypto/node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
     "node_modules/@dcl/eslint-config": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@dcl/eslint-config/-/eslint-config-1.1.6.tgz",
@@ -1033,6 +1061,11 @@
         "scrypt-js": "3.0.1"
       }
     },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+    },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.9.tgz",
@@ -1156,6 +1189,26 @@
         "@ethersproject/web": "^5.0.12",
         "bech32": "1.1.4",
         "ws": "7.2.3"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ethersproject/random": {
@@ -2247,6 +2300,50 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2300,6 +2397,45 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@scure/base": "~1.1.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3205,9 +3341,9 @@
       }
     },
     "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/ajv": {
       "version": "8.12.0",
@@ -5878,6 +6014,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eth-connect": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
+      "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
+    },
     "node_modules/eth-crypto": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-1.9.0.tgz",
@@ -5891,6 +6032,53 @@
         "ethereumjs-util": "7.0.9",
         "ethers": "5.0.32",
         "secp256k1": "4.0.2"
+      }
+    },
+    "node_modules/eth-crypto/node_modules/ethers": {
+      "version": "5.0.32",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
+      "integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.0.13",
+        "@ethersproject/abstract-provider": "5.0.10",
+        "@ethersproject/abstract-signer": "5.0.14",
+        "@ethersproject/address": "5.0.11",
+        "@ethersproject/base64": "5.0.9",
+        "@ethersproject/basex": "5.0.9",
+        "@ethersproject/bignumber": "5.0.15",
+        "@ethersproject/bytes": "5.0.11",
+        "@ethersproject/constants": "5.0.10",
+        "@ethersproject/contracts": "5.0.12",
+        "@ethersproject/hash": "5.0.12",
+        "@ethersproject/hdnode": "5.0.10",
+        "@ethersproject/json-wallets": "5.0.12",
+        "@ethersproject/keccak256": "5.0.9",
+        "@ethersproject/logger": "5.0.10",
+        "@ethersproject/networks": "5.0.9",
+        "@ethersproject/pbkdf2": "5.0.9",
+        "@ethersproject/properties": "5.0.9",
+        "@ethersproject/providers": "5.0.24",
+        "@ethersproject/random": "5.0.9",
+        "@ethersproject/rlp": "5.0.9",
+        "@ethersproject/sha2": "5.0.9",
+        "@ethersproject/signing-key": "5.0.11",
+        "@ethersproject/solidity": "5.0.10",
+        "@ethersproject/strings": "5.0.10",
+        "@ethersproject/transactions": "5.0.11",
+        "@ethersproject/units": "5.0.11",
+        "@ethersproject/wallet": "5.0.12",
+        "@ethersproject/web": "5.0.14",
+        "@ethersproject/wordlists": "5.0.10"
       }
     },
     "node_modules/eth-lib": {
@@ -5985,13 +6173,13 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/ethers": {
-      "version": "5.0.32",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.32.tgz",
-      "integrity": "sha512-rORfGWR0HsA4pjKMMcWZorw12DHsXqfIAuPVHJsXt+vI24jvXcVqx+rLsSvgOoLdaCMdxiN5qlIq2+4axKG31g==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.9.1.tgz",
+      "integrity": "sha512-kuV8fGd4/8Gj7wkurbsuUsm1DCG6N5gKGYdw3fnWG/7QGknhy1xtHD7kbkCWQAcbAYmzLCLqCPedS3FYncFkKQ==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -5999,37 +6187,38 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.0.13",
-        "@ethersproject/abstract-provider": "5.0.10",
-        "@ethersproject/abstract-signer": "5.0.14",
-        "@ethersproject/address": "5.0.11",
-        "@ethersproject/base64": "5.0.9",
-        "@ethersproject/basex": "5.0.9",
-        "@ethersproject/bignumber": "5.0.15",
-        "@ethersproject/bytes": "5.0.11",
-        "@ethersproject/constants": "5.0.10",
-        "@ethersproject/contracts": "5.0.12",
-        "@ethersproject/hash": "5.0.12",
-        "@ethersproject/hdnode": "5.0.10",
-        "@ethersproject/json-wallets": "5.0.12",
-        "@ethersproject/keccak256": "5.0.9",
-        "@ethersproject/logger": "5.0.10",
-        "@ethersproject/networks": "5.0.9",
-        "@ethersproject/pbkdf2": "5.0.9",
-        "@ethersproject/properties": "5.0.9",
-        "@ethersproject/providers": "5.0.24",
-        "@ethersproject/random": "5.0.9",
-        "@ethersproject/rlp": "5.0.9",
-        "@ethersproject/sha2": "5.0.9",
-        "@ethersproject/signing-key": "5.0.11",
-        "@ethersproject/solidity": "5.0.10",
-        "@ethersproject/strings": "5.0.10",
-        "@ethersproject/transactions": "5.0.11",
-        "@ethersproject/units": "5.0.11",
-        "@ethersproject/wallet": "5.0.12",
-        "@ethersproject/web": "5.0.14",
-        "@ethersproject/wordlists": "5.0.10"
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -12887,11 +13076,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@dcl/crypto": "^3.4.5",
     "@dcl/schemas": "^9.6.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-requests-logger-component": "^2.1.0",
@@ -49,6 +50,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "decentraland-crypto-middleware": "^1.1.0",
+    "ethers": "^6.9.1",
     "express": "^4.18.2",
     "socket.io": "^4.7.2",
     "uuid": "^9.0.1"

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -3,7 +3,9 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 import express from 'express'
 import { Server, Socket } from 'socket.io'
 import { v4 as uuid } from 'uuid'
+import { Authenticator, parseEmphemeralPayload } from '@dcl/crypto'
 import { AppComponents } from '../../types'
+import { METHOD_DCL_PERSONAL_SIGN } from './constants'
 import {
   IServerComponent,
   InvalidResponseMessage,
@@ -16,8 +18,6 @@ import {
   RequestResponseMessage
 } from './types'
 import { validateOutcomeMessage, validateRecoverMessage, validateRequestMessage } from './validations'
-import { Authenticator, parseEmphemeralPayload } from '@dcl/crypto'
-import { METHOD_DCL_PERSONAL_SIGN } from './constants'
 
 export async function createServerComponent({
   config,

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -16,6 +16,8 @@ import {
   RequestResponseMessage
 } from './types'
 import { validateOutcomeMessage, validateRecoverMessage, validateRequestMessage } from './validations'
+import { Authenticator, parseEmphemeralPayload } from '@dcl/crypto'
+import { METHOD_DCL_PERSONAL_SIGN } from './constants'
 
 export async function createServerComponent({
   config,
@@ -60,7 +62,7 @@ export async function createServerComponent({
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    socket.on(MessageType.REQUEST, (data: any, cb) => {
+    socket.on(MessageType.REQUEST, async (data: any, cb) => {
       let msg: RequestMessage
 
       try {
@@ -71,6 +73,44 @@ export async function createServerComponent({
         })
 
         return
+      }
+
+      let sender: string | undefined
+
+      if (msg.method !== METHOD_DCL_PERSONAL_SIGN) {
+        const authChain = msg.authChain
+
+        if (!authChain) {
+          ack<InvalidResponseMessage>(cb, {
+            error: 'Auth chain is required'
+          })
+
+          return
+        }
+
+        sender = Authenticator.ownerAddress(authChain)
+
+        let finalAuthority: string
+
+        try {
+          finalAuthority = parseEmphemeralPayload(authChain[authChain.length - 1].payload).ephemeralAddress
+        } catch (e) {
+          ack<InvalidResponseMessage>(cb, {
+            error: 'Could not get final authority from auth chain'
+          })
+
+          return
+        }
+
+        const validationResult = await Authenticator.validateSignature(finalAuthority, authChain, null)
+
+        if (!validationResult.ok) {
+          ack<InvalidResponseMessage>(cb, {
+            error: validationResult.message ?? 'Signature validation failed'
+          })
+
+          return
+        }
       }
 
       const requestId = uuid()
@@ -84,8 +124,7 @@ export async function createServerComponent({
         code,
         method: msg.method,
         params: msg.params,
-        chainId: msg.chainId,
-        sender: msg.sender
+        sender: sender?.toLowerCase()
       })
 
       ack<RequestResponseMessage>(cb, {
@@ -134,8 +173,7 @@ export async function createServerComponent({
         code: request.code,
         method: request.method,
         params: request.params,
-        sender: request.sender,
-        chainId: request.chainId
+        sender: request.sender
       })
     })
 

--- a/src/ports/server/constants.ts
+++ b/src/ports/server/constants.ts
@@ -1,0 +1,1 @@
+export const METHOD_DCL_PERSONAL_SIGN = 'dcl_personal_sign'

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -1,3 +1,4 @@
+import { AuthChain } from '@dcl/schemas'
 import { IBaseComponent } from '@well-known-components/interfaces'
 
 export type IServerComponent = IBaseComponent
@@ -13,11 +14,11 @@ export type Request = {
   method: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any[]
-  sender?: string
-  chainId?: number
 }
 
-export type RequestMessage = Request
+export type RequestMessage = Request & {
+  authChain?: AuthChain
+}
 
 export type RequestResponseMessage = {
   requestId: string
@@ -32,6 +33,7 @@ export type RecoverMessage = {
 export type RecoverResponseMessage = Request & {
   expiration: Date
   code: number
+  sender?: string
 }
 
 export type Outcome = {

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -1,5 +1,5 @@
-import { AuthChain } from '@dcl/schemas'
 import { IBaseComponent } from '@well-known-components/interfaces'
+import { AuthChain } from '@dcl/schemas'
 
 export type IServerComponent = IBaseComponent
 

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -1,5 +1,7 @@
 import Ajv from 'ajv'
+import { AuthChain } from '@dcl/schemas'
 import { OutcomeMessage, RecoverMessage, RequestMessage } from './types'
+
 const ajv = new Ajv({ allowUnionTypes: true })
 
 const requestMessageSchema = {
@@ -11,12 +13,7 @@ const requestMessageSchema = {
     params: {
       type: 'array'
     },
-    sender: {
-      type: 'string'
-    },
-    chainId: {
-      type: 'number'
-    }
+    authChain: AuthChain.schema
   },
   required: ['method', 'params'],
   additionalProperties: false

--- a/src/ports/storage/types.ts
+++ b/src/ports/storage/types.ts
@@ -11,4 +11,5 @@ export type StorageRequest = Request & {
   socketId: string
   expiration: Date
   code: number
+  sender?: string
 }

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -1,11 +1,11 @@
 import { TestArguments } from '@well-known-components/test-helpers'
+import { ethers } from 'ethers'
 import { Socket, io } from 'socket.io-client'
+import { AuthChain, Authenticator, AuthLinkType } from '@dcl/crypto'
+import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
 import { MessageType } from '../../src/ports/server/types'
 import { BaseComponents } from '../../src/types'
 import { test, testWithOverrides } from '../components'
-import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
-import { ethers } from 'ethers'
-import { AuthChain, Authenticator, AuthLinkType } from '@dcl/crypto'
 
 let desktopClientSocket: Socket
 let authDappSocket: Socket
@@ -110,7 +110,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
       })
 
       expect(response).toEqual({
-        error: `Auth chain is required`
+        error: 'Auth chain is required'
       })
     })
   })
@@ -177,7 +177,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
           authChain
         })
 
-        expect(requestResponse.error).toEqual(`Could not get final authority from auth chain`)
+        expect(requestResponse.error).toEqual('Could not get final authority from auth chain')
       })
     })
   })

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -152,6 +152,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
 
         authChain[0].payload = otherAccount.address
       })
+
       it('should respond with an invalid response message, indicating that the expected signer address is different', async () => {
         const requestResponse = await desktopClientSocket.emitWithAck(MessageType.REQUEST, {
           method: 'method',


### PR DESCRIPTION
On messages that are not for dcl_personal_sign

Request have to contain authChain property. The server will validate it as well as extract the owner from it.

If invalid. The request will be rejected.

If valid. When the request is recovered, the recover response message will provide a sender property which can be used by the frontend to check that the connected wallet is the same address as the one that sent the message.