### PR TITLE
feat: Add message request validation status

### DIFF
--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -365,12 +365,14 @@ export async function createServerComponent({
               })
             }
 
-            if (request.socketId && sockets[request.socketId]) {
+            if (request.socketId && sockets[request.socketId] && !request.requiresValidation) {
               const storedSocket = sockets[request.socketId]
 
               // Relay the request validation to the client
               storedSocket.emit(MessageType.REQUEST_VALIDATION_STATUS, { requestId: msg.requestId, code: request.code })
             }
+
+            request.requiresValidation = true
 
             ack<object>(cb, {})
           },
@@ -530,7 +532,7 @@ export async function createServerComponent({
         })
       }
 
-      if (request.socketId && sockets[request.socketId]) {
+      if (request.socketId && sockets[request.socketId] && !request.requiresValidation) {
         const storedSocket = sockets[request.socketId]
 
         logger.log(`[RID:${requestId}] Successfully sent request validation to the client via socket`)

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -331,7 +331,7 @@ export async function createServerComponent({
       )
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      socket.on(MessageType.REQUEST_VALIDATION, (data: any, cb) => {
+      socket.on(MessageType.REQUEST_VALIDATION_STATUS, (data: any, cb) => {
         tracer.span(
           'websocket-request-validation',
           () => {
@@ -369,7 +369,7 @@ export async function createServerComponent({
               const storedSocket = sockets[request.socketId]
 
               // Relay the request validation to the client
-              storedSocket.emit(MessageType.REQUEST_VALIDATION, { requestId: msg.requestId, code: request.code })
+              storedSocket.emit(MessageType.REQUEST_VALIDATION_STATUS, { requestId: msg.requestId, code: request.code })
             }
 
             ack<object>(cb, {})
@@ -535,12 +535,10 @@ export async function createServerComponent({
 
         logger.log(`[RID:${requestId}] Successfully sent request validation to the client via socket`)
         // Send the request validation to the client
-        storedSocket.emit(MessageType.REQUEST_VALIDATION, { requestId })
+        storedSocket.emit(MessageType.REQUEST_VALIDATION_STATUS, { requestId })
       }
 
       request.requiresValidation = true
-
-      logger.log(`[RID:${requestId}] Done! `)
 
       res.sendStatus(204)
     })
@@ -661,8 +659,6 @@ export async function createServerComponent({
           requestId
         }
       }
-
-      logger.log(`[RID:${requestId}] Done! `)
 
       return res.sendStatus(200)
     })

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -19,9 +19,17 @@ import {
   RecoverMessage,
   RecoverResponseMessage,
   RequestMessage,
-  RequestResponseMessage
+  RequestResponseMessage,
+  RequestValidationMessage,
+  RequestValidationStatusMessage
 } from './types'
-import { validateHttpOutcomeMessage, validateOutcomeMessage, validateRecoverMessage, validateRequestMessage } from './validations'
+import {
+  validateHttpOutcomeMessage,
+  validateOutcomeMessage,
+  validateRecoverMessage,
+  validateRequestMessage,
+  validateRequestValidationMessage
+} from './validations'
 
 export async function createServerComponent({
   config,
@@ -156,6 +164,7 @@ export async function createServerComponent({
             storage.setRequest(requestId, {
               requestId: requestId,
               socketId: socket.id,
+              requiresValidation: false,
               expiration,
               code,
               method: msg.method,
@@ -240,7 +249,6 @@ export async function createServerComponent({
           'websocket-outcome',
           () => {
             let msg: OutcomeMessage
-            logger.log('Received an outcome message')
 
             try {
               msg = validateOutcomeMessage(data)
@@ -321,6 +329,54 @@ export async function createServerComponent({
           parentTracingContext
         )
       )
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      socket.on(MessageType.REQUEST_VALIDATION, (data: any, cb) => {
+        tracer.span(
+          'websocket-request-validation',
+          () => {
+            let msg: RequestValidationMessage
+
+            try {
+              msg = validateRequestValidationMessage(data)
+            } catch (e) {
+              logger.log('Received an outcome message with invalid message')
+              return ack<InvalidResponseMessage>(cb, {
+                error: (e as Error).message
+              })
+            }
+
+            const request = storage.getRequest(msg.requestId)
+
+            // If the response was already received, it's like the request doesn't exist anymore
+            if (!request) {
+              logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it doesn't exist`)
+              return ack<InvalidResponseMessage>(cb, {
+                error: `Request with id "${msg.requestId}" not found`
+              })
+            }
+
+            if (request.expiration < new Date()) {
+              storage.setRequest(msg.requestId, null)
+
+              logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it has expired`)
+              return ack<InvalidResponseMessage>(cb, {
+                error: `Request with id "${msg.requestId}" has expired`
+              })
+            }
+
+            if (request.socketId && sockets[request.socketId]) {
+              const storedSocket = sockets[request.socketId]
+
+              // Relay the request validation to the client
+              storedSocket.emit(MessageType.REQUEST_VALIDATION, { requestId: msg.requestId, code: request.code })
+            }
+
+            ack<object>(cb, {})
+          },
+          parentTracingContext
+        )
+      })
     })
 
   const start: IBaseComponent['start'] = async () => {
@@ -362,11 +418,9 @@ export async function createServerComponent({
       try {
         msg = validateRequestMessage(data)
       } catch (e) {
-        sendResponse<InvalidResponseMessage>(res, 400, {
+        return sendResponse<InvalidResponseMessage>(res, 400, {
           error: (e as Error).message
         })
-
-        return
       }
 
       let sender: string | undefined
@@ -375,11 +429,9 @@ export async function createServerComponent({
         const authChain = msg.authChain
 
         if (!authChain) {
-          sendResponse<InvalidResponseMessage>(res, 400, {
+          return sendResponse<InvalidResponseMessage>(res, 400, {
             error: 'Auth chain is required'
           })
-
-          return
         }
 
         sender = Authenticator.ownerAddress(authChain)
@@ -389,26 +441,24 @@ export async function createServerComponent({
         try {
           finalAuthority = parseEmphemeralPayload(authChain[authChain.length - 1].payload).ephemeralAddress
         } catch (e) {
-          sendResponse<InvalidResponseMessage>(res, 400, {
+          return sendResponse<InvalidResponseMessage>(res, 400, {
             error: 'Could not get final authority from auth chain'
           })
-
-          return
         }
 
         const validationResult = await Authenticator.validateSignature(finalAuthority, authChain, null)
 
         if (!validationResult.ok) {
-          sendResponse<InvalidResponseMessage>(res, 400, {
+          return sendResponse<InvalidResponseMessage>(res, 400, {
             error: validationResult.message ?? 'Signature validation failed'
           })
-
-          return
         }
       }
 
       const requestId = uuid()
-      const expiration = new Date(Date.now() + requestExpirationInSeconds * 1000)
+      const expiration = new Date(
+        Date.now() + (msg.method !== METHOD_DCL_PERSONAL_SIGN ? requestExpirationInSeconds : dclPersonalSignExpirationInSeconds) * 1000
+      )
       const code = Math.floor(Math.random() * 100)
 
       storage.setRequest(requestId, {
@@ -417,7 +467,8 @@ export async function createServerComponent({
         code,
         method: msg.method,
         params: msg.params,
-        sender: sender?.toLowerCase()
+        sender: sender?.toLowerCase(),
+        requiresValidation: false
       })
 
       sendResponse<RequestResponseMessage>(res, 201, {
@@ -433,21 +484,17 @@ export async function createServerComponent({
       const request = storage.getRequest(requestId)
 
       if (!request) {
-        sendResponse<InvalidResponseMessage>(res, 404, {
+        return sendResponse<InvalidResponseMessage>(res, 404, {
           error: `Request with id "${requestId}" not found`
         })
-
-        return
       }
 
       if (request.expiration < new Date()) {
         storage.setRequest(requestId, null)
 
-        sendResponse<InvalidResponseMessage>(res, 410, {
+        return sendResponse<InvalidResponseMessage>(res, 410, {
           error: `Request with id "${requestId}" has expired`
         })
-
-        return
       }
 
       sendResponse<RecoverResponseMessage>(res, 200, {
@@ -459,41 +506,99 @@ export async function createServerComponent({
       })
     })
 
+    // Communicate that the request must be validated
+    app.post('/v2/requests/:requestId/validation', async (req: Request, res: Response) => {
+      const requestId = req.params.requestId
+
+      const request = storage.getRequest(requestId)
+
+      if (!request) {
+        logger.log(`[RID:${requestId}] Received a validation request message for a non-existent request`)
+        return sendResponse<InvalidResponseMessage>(res, 404, {
+          error: `Request with id "${requestId}" not found`
+        })
+      }
+
+      if (request.expiration < new Date()) {
+        logger.log(`[RID:${requestId}] Received a validation request message for an expired request`)
+
+        // Remove the request from the storage as it is expired
+        storage.setRequest(requestId, null)
+
+        return sendResponse<InvalidResponseMessage>(res, 410, {
+          error: `Request with id "${requestId}" has expired`
+        })
+      }
+
+      if (request.socketId && sockets[request.socketId]) {
+        const storedSocket = sockets[request.socketId]
+
+        logger.log(`[RID:${requestId}] Successfully sent request validation to the client via socket`)
+        // Send the request validation to the client
+        storedSocket.emit(MessageType.REQUEST_VALIDATION, { requestId })
+      }
+
+      request.requiresValidation = true
+
+      logger.log(`[RID:${requestId}] Done! `)
+
+      res.sendStatus(204)
+    })
+
+    // Get the request validation status
+    app.get('/v2/requests/:requestId/validation', async (req: Request, res: Response) => {
+      const requestId = req.params.requestId
+      const request = storage.getRequest(requestId)
+
+      if (!request) {
+        return sendResponse<InvalidResponseMessage>(res, 404, {
+          error: `Request with id "${requestId}" not found`
+        })
+      }
+
+      if (request.expiration < new Date()) {
+        storage.setRequest(requestId, null)
+
+        return sendResponse<InvalidResponseMessage>(res, 410, {
+          error: `Request with id "${requestId}" has expired`
+        })
+      }
+
+      sendResponse<RequestValidationStatusMessage>(res, 200, { requiresValidation: request.requiresValidation })
+    })
+
     // Get the outcome of a request
     app.get('/requests/:requestId', async (req: Request, res: Response) => {
       const requestId = req.params.requestId
       const request = storage.getRequest(requestId)
 
       if (!request) {
-        sendResponse<InvalidResponseMessage>(res, 404, {
+        return sendResponse<InvalidResponseMessage>(res, 404, {
           error: `Request with id "${requestId}" not found`
         })
-        return
       }
 
       if (request.expiration < new Date()) {
         storage.setRequest(requestId, null)
-        sendResponse<InvalidResponseMessage>(res, 410, {
+        return sendResponse<InvalidResponseMessage>(res, 410, {
           error: `Request with id "${requestId}" has expired`
         })
-
-        return
       }
 
       if (!request.response) {
-        sendResponse<InvalidResponseMessage>(res, 204, {
+        return sendResponse<InvalidResponseMessage>(res, 204, {
           error: `Request with id "${requestId}" has not been completed`
         })
-
-        return
       }
+
+      logger.log(`[RID:${requestId}] Successfully sent outcome message to the client via HTTP`)
 
       storage.setRequest(requestId, null)
       sendResponse<OutcomeResponseMessage>(res, 200, request.response)
     })
 
     // Record the outcome of a request
-    app.post('/v2/outcomes/:requestId', async (req: Request, res: Response) => {
+    app.post('/v2/requests/:requestId/outcome', async (req: Request, res: Response) => {
       const requestId = req.params.requestId
 
       const data = req.body
@@ -502,46 +607,36 @@ export async function createServerComponent({
       try {
         msg = validateHttpOutcomeMessage(data)
       } catch (e) {
-        sendResponse<InvalidResponseMessage>(res, 400, {
+        return sendResponse<InvalidResponseMessage>(res, 400, {
           error: (e as Error).message
         })
-
-        return
       }
 
       const request = storage.getRequest(requestId)
 
       // If the response was already received, it's like the request doesn't exist anymore
       if (!request) {
-        sendResponse<InvalidResponseMessage>(res, 404, {
+        logger.log(`[RID:${requestId}] Received an outcome message for a non-existent request`)
+        return sendResponse<InvalidResponseMessage>(res, 404, {
           error: `Request with id "${requestId}" not found`
         })
-
-        logger.log(`[RID:${requestId}] Received an outcome message for a non-existent request`)
-
-        return
       }
 
       if (request.response) {
-        sendResponse<InvalidResponseMessage>(res, 400, {
-          error: `Request with id "${requestId}" already has a response`
-        })
-
         logger.log(`[RID:${requestId}] Received an outcome message for a request that already has a response`)
 
-        return
+        return sendResponse<InvalidResponseMessage>(res, 400, {
+          error: `Request with id "${requestId}" already has a response`
+        })
       }
 
       if (request.expiration < new Date()) {
         storage.setRequest(requestId, null)
 
-        sendResponse<InvalidResponseMessage>(res, 410, {
+        logger.log(`[RID:${requestId}] Received an outcome message for an expired request`)
+        return sendResponse<InvalidResponseMessage>(res, 410, {
           error: `Request with id "${requestId}" has expired`
         })
-
-        logger.log(`[RID:${requestId}] Received an outcome message for an expired request`)
-
-        return
       }
 
       const outcomeMessage: OutcomeResponseMessage = {
@@ -566,6 +661,8 @@ export async function createServerComponent({
           requestId
         }
       }
+
+      logger.log(`[RID:${requestId}] Done! `)
 
       return res.sendStatus(200)
     })

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -7,7 +7,8 @@ export enum MessageType {
   REQUEST = 'request',
   RECOVER = 'recover',
   OUTCOME = 'outcome',
-  INVALID = 'invalid'
+  INVALID = 'invalid',
+  REQUEST_VALIDATION = 'request-validation'
 }
 
 export type Request = {
@@ -51,6 +52,14 @@ export type Outcome = {
 
 export type OutcomeMessage = Outcome & {
   requestId: string
+}
+
+export type RequestValidationMessage = {
+  requestId: string
+}
+
+export type RequestValidationStatusMessage = {
+  requiresValidation: boolean
 }
 
 export type HttpOutcomeMessage = Outcome

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -8,7 +8,7 @@ export enum MessageType {
   RECOVER = 'recover',
   OUTCOME = 'outcome',
   INVALID = 'invalid',
-  REQUEST_VALIDATION = 'request-validation'
+  REQUEST_VALIDATION_STATUS = 'request-validation-status'
 }
 
 export type Request = {

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -1,6 +1,6 @@
 import Ajv from 'ajv'
 import { AuthChain } from '@dcl/schemas'
-import { HttpOutcomeMessage, OutcomeMessage, RecoverMessage, RequestMessage } from './types'
+import { HttpOutcomeMessage, OutcomeMessage, RecoverMessage, RequestMessage, RequestValidationMessage } from './types'
 
 const ajv = new Ajv({ allowUnionTypes: true })
 
@@ -72,10 +72,19 @@ const httpOutcomeMessageSchema = {
   required: ['sender']
 }
 
+const requestValidationMessageSchema = {
+  type: 'object',
+  properties: {
+    requestId: { type: 'string' }
+  },
+  required: ['requestId']
+}
+
 const requestMessageValidator = ajv.compile(requestMessageSchema)
 const recoverMessageValidator = ajv.compile(recoverMessageSchema)
 const outcomeMessageValidator = ajv.compile(outcomeMessageSchema)
 const httpOutcomeMessageValidator = ajv.compile(httpOutcomeMessageSchema)
+const requestValidationMessageValidator = ajv.compile(requestValidationMessageSchema)
 
 export function validateRequestMessage(msg: unknown) {
   if (!requestMessageValidator(msg)) {
@@ -99,6 +108,14 @@ export function validateOutcomeMessage(msg: unknown) {
   }
 
   return msg as OutcomeMessage
+}
+
+export function validateRequestValidationMessage(msg: unknown) {
+  if (!requestValidationMessageValidator(msg)) {
+    throw new Error(JSON.stringify(requestValidationMessageValidator.errors))
+  }
+
+  return msg as RequestValidationMessage
 }
 
 export function validateHttpOutcomeMessage(msg: unknown) {

--- a/src/ports/storage/types.ts
+++ b/src/ports/storage/types.ts
@@ -13,4 +13,5 @@ export type StorageRequest = Request & {
   code: number
   sender?: string
   response?: OutcomeResponseMessage
+  requiresValidation: boolean
 }

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -593,7 +593,8 @@ test('when posting that a request needs validation and the request is valid', ar
       })
 
       return expect(promiseOfRequestValidation).resolves.toEqual({
-        requestId: requestResponse.requestId
+        requestId: requestResponse.requestId,
+        code: requestResponse.code
       })
     })
   })

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -1,11 +1,12 @@
 import { TestArguments } from '@well-known-components/test-helpers'
 import { ethers } from 'ethers'
-import { Socket, io } from 'socket.io-client'
+import { Socket } from 'socket.io-client'
 import { AuthChain, Authenticator, AuthLinkType } from '@dcl/crypto'
 import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
-import { MessageType } from '../../src/ports/server/types'
+import { MessageType, RequestResponseMessage, RequestValidationMessage } from '../../src/ports/server/types'
 import { BaseComponents } from '../../src/types'
 import { test, testWithOverrides } from '../components'
+import { createAuthWsClient } from '../utils'
 
 let desktopClientSocket: Socket
 let authDappSocket: Socket
@@ -16,25 +17,10 @@ afterEach(() => {
 })
 
 async function connectClients(args: TestArguments<BaseComponents>) {
-  const port = await args.components.config.getString('HTTP_SERVER_PORT')
+  const port = await args.components.config.requireString('HTTP_SERVER_PORT')
 
-  desktopClientSocket = io(`http://localhost:${port}`)
-  authDappSocket = io(`http://localhost:${port}`)
-
-  await new Promise(resolve => {
-    let connected = 0
-
-    const handleOnConnect = () => {
-      connected++
-
-      if (connected === 2) {
-        resolve(undefined)
-      }
-    }
-
-    desktopClientSocket.on('connect', handleOnConnect)
-    authDappSocket.on('connect', handleOnConnect)
-  })
+  desktopClientSocket = await createAuthWsClient(port)
+  authDappSocket = await createAuthWsClient(port)
 }
 
 test('when sending a request message with an invalid schema', args => {
@@ -536,6 +522,96 @@ test('when the auth dapp sends an outcome message', args => {
 
     expect(outcomeResponse).toEqual({
       error: `Request with id "${requestResponse.requestId}" not found`
+    })
+  })
+})
+
+testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
+  'when posting that a request needs validation but the request has expired',
+  args => {
+    beforeEach(async () => {
+      await connectClients(args)
+    })
+
+    it('should respond with an error indicating that the request has expired', async () => {
+      const requestResponse = await desktopClientSocket.emitWithAck(MessageType.REQUEST, {
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })
+
+      const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+        requestId: requestResponse.requestId
+      })
+
+      expect(response).toEqual({
+        error: `Request with id "${requestResponse.requestId}" has expired`
+      })
+    })
+  }
+)
+
+test('when posting that a request needs validation but the request does not exist', args => {
+  beforeEach(async () => {
+    await connectClients(args)
+  })
+
+  it('should respond with an error indicating that the request does not exist', async () => {
+    const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+      requestId: 'requestId'
+    })
+
+    expect(response).toEqual({
+      error: 'Request with id "requestId" not found'
+    })
+  })
+})
+
+test('when posting that a request needs validation and the request is valid', args => {
+  let requestResponse: RequestResponseMessage
+
+  beforeEach(async () => {
+    await connectClients(args)
+  })
+
+  describe('and there is a client connected listening for the request validation', () => {
+    beforeEach(async () => {
+      requestResponse = (await desktopClientSocket.emitWithAck('request', {
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })) as RequestResponseMessage
+    })
+
+    it('should respond with an empty object as ack and send the request validation to the client', async () => {
+      const promiseOfRequestValidation = new Promise<RequestValidationMessage>((resolve, _) => {
+        desktopClientSocket.on(MessageType.REQUEST_VALIDATION, (data: RequestValidationMessage) => {
+          resolve(data)
+        })
+      })
+
+      await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+        requestId: requestResponse.requestId
+      })
+
+      return expect(promiseOfRequestValidation).resolves.toEqual({
+        requestId: requestResponse.requestId
+      })
+    })
+  })
+
+  describe('and there is no client connected listening for the request validation', () => {
+    beforeEach(async () => {
+      requestResponse = (await desktopClientSocket.emitWithAck(MessageType.REQUEST, {
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })) as RequestResponseMessage
+    })
+
+    it('should respond with an empty object as ack', async () => {
+      return expect(
+        authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+          requestId: requestResponse.requestId
+        })
+      ).resolves.toEqual({})
     })
   })
 })

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -539,7 +539,7 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
         params: []
       })
 
-      const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+      const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
         requestId: requestResponse.requestId
       })
 
@@ -556,7 +556,7 @@ test('when posting that a request needs validation but the request does not exis
   })
 
   it('should respond with an error indicating that the request does not exist', async () => {
-    const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+    const response = await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
       requestId: 'requestId'
     })
 
@@ -583,12 +583,12 @@ test('when posting that a request needs validation and the request is valid', ar
 
     it('should respond with an empty object as ack and send the request validation to the client', async () => {
       const promiseOfRequestValidation = new Promise<RequestValidationMessage>((resolve, _) => {
-        desktopClientSocket.on(MessageType.REQUEST_VALIDATION, (data: RequestValidationMessage) => {
+        desktopClientSocket.on(MessageType.REQUEST_VALIDATION_STATUS, (data: RequestValidationMessage) => {
           resolve(data)
         })
       })
 
-      await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+      await authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
         requestId: requestResponse.requestId
       })
 
@@ -609,7 +609,7 @@ test('when posting that a request needs validation and the request is valid', ar
 
     it('should respond with an empty object as ack', async () => {
       return expect(
-        authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION, {
+        authDappSocket.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
           requestId: requestResponse.requestId
         })
       ).resolves.toEqual({})

--- a/test/integration/with-polling.spec.ts
+++ b/test/integration/with-polling.spec.ts
@@ -385,7 +385,7 @@ test('when posting that a request needs validation and the request is valid', ar
 
     it('should respond with a 204 and a valid response message and send the request validation to the client', async () => {
       const promiseOfRequestValidation = new Promise<RequestValidationMessage>((resolve, _) => {
-        wsClient.on(MessageType.REQUEST_VALIDATION, (data: RequestValidationMessage) => {
+        wsClient.on(MessageType.REQUEST_VALIDATION_STATUS, (data: RequestValidationMessage) => {
           resolve(data)
         })
       })

--- a/test/integration/with-polling.spec.ts
+++ b/test/integration/with-polling.spec.ts
@@ -1,123 +1,29 @@
-import { TestArguments } from '@well-known-components/test-helpers'
 import { ethers } from 'ethers'
-import { Socket, io } from 'socket.io-client'
+import { DefaultEventsMap } from 'socket.io/dist/typed-events'
+import { Socket } from 'socket.io-client'
 import { AuthChain, Authenticator, AuthLinkType } from '@dcl/crypto'
 import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
-import { OutcomeResponseMessage, RecoverResponseMessage, RequestResponseMessage } from '../../src/ports/server/types'
-import { BaseComponents } from '../../src/types'
+import { MessageType, OutcomeResponseMessage, RequestResponseMessage, RequestValidationMessage } from '../../src/ports/server/types'
 import { test, testWithOverrides } from '../components'
+import { createHttpClient, createAuthWsClient, HttpPollingClient } from '../utils'
 
-let desktopHTTPClient: HttpPollingClient
-let authDappSocket: Socket
-
-type HttpPollingClient = {
-  request(data: unknown): Promise<RequestResponseMessage | { error: string }>
-  sendSuccessfulOutcome(requestId: string, sender: string, result: unknown): Promise<{ error: string } | undefined>
-  sendFailedOutcome(requestId: string, sender: string, error: { code: number; message: string }): Promise<{ error: string } | undefined>
-  getOutcome(requestId: string): Promise<OutcomeResponseMessage | undefined>
-  recover(requestId: string): Promise<RecoverResponseMessage>
-}
-
-function createHttpClient(url: string): HttpPollingClient {
-  return {
-    async request(data: unknown): Promise<RequestResponseMessage | { error: string }> {
-      // Make a post request
-      const response = await fetch(`${url}/requests`, {
-        method: 'POST',
-        body: JSON.stringify(data),
-        headers: [
-          ['Content-Type', 'application/json'],
-          ['Origin', 'http://localhost:3000']
-        ]
-      })
-
-      return response.json()
-    },
-    async sendSuccessfulOutcome(requestId: string, sender: string, result: unknown): Promise<{ error: string } | undefined> {
-      const response = await fetch(`${url}/v2/outcomes/${requestId}`, {
-        method: 'POST',
-        body: JSON.stringify({ sender, result }),
-        headers: [['Content-Type', 'application/json']]
-      })
-      let body: { error: string } | undefined
-
-      try {
-        body = await response.json()
-      } catch (e) {
-        return undefined
-      }
-
-      return body
-    },
-    async sendFailedOutcome(
-      requestId: string,
-      sender: string,
-      error: { code: number; message: string }
-    ): Promise<{ error: string } | undefined> {
-      const response = await fetch(`${url}/v2/outcomes/${requestId}`, {
-        method: 'POST',
-        body: JSON.stringify({ sender, error }),
-        headers: [['Content-Type', 'application/json']]
-      })
-      let body: { error: string } | undefined
-
-      try {
-        body = await response.json()
-      } catch (e) {
-        return undefined
-      }
-
-      return body
-    },
-    async recover(requestId: string): Promise<RecoverResponseMessage> {
-      const response = await fetch(`${url}/v2/requests/${requestId}`, {
-        method: 'GET',
-        headers: [['Origin', 'http://localhost:3000']]
-      })
-
-      return response.json()
-    },
-    async getOutcome(requestId: string): Promise<OutcomeResponseMessage | undefined> {
-      const response = await fetch(`${url}/requests/${requestId}`, {
-        method: 'GET',
-        headers: [['Origin', 'http://localhost:3000']]
-      })
-
-      if (response.status === 204) {
-        return undefined
-      }
-
-      return response.json()
-    }
-  }
-}
+let httpClient: HttpPollingClient
+let wsClient: Socket<DefaultEventsMap, DefaultEventsMap>
 
 afterEach(() => {
-  authDappSocket.close()
+  if (wsClient && wsClient.connected) {
+    wsClient.close()
+  }
 })
-
-async function connectClients(args: TestArguments<BaseComponents>) {
-  const port = await args.components.config.getString('HTTP_SERVER_PORT')
-
-  desktopHTTPClient = createHttpClient(`http://localhost:${port}`)
-  authDappSocket = io(`http://localhost:${port}`)
-
-  await new Promise(resolve => {
-    const handleOnConnect = () => {
-      resolve(undefined)
-    }
-
-    authDappSocket.on('connect', handleOnConnect)
-  })
-}
 
 test('when sending a request message with an invalid schema', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with an invalid response message', async () => {
-    const response = await desktopHTTPClient.request({})
+    const response = await httpClient.request({})
 
     expect(response).toEqual({
       error:
@@ -135,7 +41,9 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
   let authChain: AuthChain
 
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    wsClient = await createAuthWsClient(port)
+    httpClient = await createHttpClient(port)
 
     mainAccount = ethers.Wallet.createRandom()
     ephemeralAccount = ethers.Wallet.createRandom()
@@ -159,7 +67,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
 
   describe('and an auth chain is not provided', () => {
     it('should respond with an invalid response message indicating that the auth chain is required', async () => {
-      const response = await desktopHTTPClient.request({
+      const response = await httpClient.request({
         method: 'method',
         params: []
       })
@@ -172,7 +80,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
 
   describe('and an auth chain is provided', () => {
     it('should respond with the data of the request', async () => {
-      const requestResponse = await desktopHTTPClient.request({
+      const requestResponse = await httpClient.request({
         method: 'method',
         params: [],
         authChain
@@ -186,13 +94,13 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
     })
 
     it('should return the sender derived from the auth chain on the recover response', async () => {
-      const requestResponse = (await desktopHTTPClient.request({
+      const requestResponse = (await httpClient.request({
         method: 'method',
         params: [],
         authChain
       })) as RequestResponseMessage
 
-      const recoverResponse = await desktopHTTPClient.recover(requestResponse.requestId)
+      const recoverResponse = await httpClient.recover(requestResponse.requestId)
 
       expect(recoverResponse.sender).toEqual(mainAccount.address.toLowerCase())
     })
@@ -207,7 +115,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
       })
 
       it('should respond with an invalid response message, indicating that the expected signer address is different', async () => {
-        const requestResponse = (await desktopHTTPClient.request({
+        const requestResponse = (await httpClient.request({
           method: 'method',
           params: [],
           authChain
@@ -225,7 +133,7 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
       })
 
       it('should respond with an invalid response message, indicating that the final authority could not be obtained', async () => {
-        const requestResponse = (await desktopHTTPClient.request({
+        const requestResponse = (await httpClient.request({
           method: 'method',
           params: [],
           authChain
@@ -237,18 +145,19 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
   })
 })
 
-testWithOverrides({ requestExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
+testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with an invalid response message', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    const recoverResponse = await desktopHTTPClient.recover(requestResponse.requestId)
+    const recoverResponse = await httpClient.recover(requestResponse.requestId)
 
     expect(recoverResponse).toEqual({
       error: `Request with id "${requestResponse.requestId}" has expired`
@@ -258,16 +167,17 @@ testWithOverrides({ requestExpirationInSeconds: -1 })('when sending a recover me
 
 test('when sending a recover message', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with the recover data of the request', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    const recoverResponse = await desktopHTTPClient.recover(requestResponse.requestId)
+    const recoverResponse = await httpClient.recover(requestResponse.requestId)
 
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
@@ -280,16 +190,17 @@ test('when sending a recover message', args => {
 
 test('when sending an outcome message with an invalid schema', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with an invalid response message', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    const response = await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', undefined)
+    const response = await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', undefined)
 
     expect(response).toEqual({
       error:
@@ -300,11 +211,12 @@ test('when sending an outcome message with an invalid schema', args => {
 
 test('when sending an outcome message but the request does not exist', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with an invalid response message', async () => {
-    const response = await desktopHTTPClient.sendSuccessfulOutcome('requestId', 'sender', 'result')
+    const response = await httpClient.sendSuccessfulOutcome('requestId', 'sender', 'result')
 
     expect(response).toEqual({
       error: 'Request with id "requestId" not found'
@@ -312,18 +224,19 @@ test('when sending an outcome message but the request does not exist', args => {
   })
 })
 
-testWithOverrides({ requestExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
+testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
   })
 
   it('should respond with an invalid response message', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    const outcomeResponse = await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
+    const outcomeResponse = await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
 
     expect(outcomeResponse).toEqual({
       error: `Request with id "${requestResponse.requestId}" has expired`
@@ -333,18 +246,20 @@ testWithOverrides({ requestExpirationInSeconds: -1 })('when sending an outcome m
 
 test('when sending a valid outcome message with the HTTP endpoints', args => {
   beforeEach(async () => {
-    await connectClients(args)
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
+    wsClient = await createAuthWsClient(port)
   })
 
   it('should respond with the outcome response message', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
+    await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
 
-    const outcomeResponse = await desktopHTTPClient.getOutcome(requestResponse.requestId)
+    const outcomeResponse = await httpClient.getOutcome(requestResponse.requestId)
 
     expect(outcomeResponse).toEqual({
       requestId: requestResponse.requestId,
@@ -354,18 +269,18 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
   })
 
   it('should send the outcome response message to a websocket connected client when the outcome is sent via the HTTP', async () => {
-    const requestResponse = (await authDappSocket.emitWithAck('request', {
+    const requestResponse = (await wsClient.emitWithAck('request', {
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
     const promiseOfAnOutcome = new Promise<OutcomeResponseMessage>((resolve, _) => {
-      authDappSocket.on('outcome', (data: OutcomeResponseMessage) => {
+      wsClient.on(MessageType.OUTCOME, (data: OutcomeResponseMessage) => {
         resolve(data)
       })
     })
 
-    await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
+    await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
 
     return expect(promiseOfAnOutcome).resolves.toEqual({
       requestId: requestResponse.requestId,
@@ -375,17 +290,17 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
   })
 
   it('should respond with the outcome response message with an error', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    await desktopHTTPClient.sendFailedOutcome(requestResponse.requestId, 'sender', {
+    await httpClient.sendFailedOutcome(requestResponse.requestId, 'sender', {
       code: 1233,
       message: 'anErrorOccurred'
     })
 
-    const outcomeResponse = await desktopHTTPClient.getOutcome(requestResponse.requestId)
+    const outcomeResponse = await httpClient.getOutcome(requestResponse.requestId)
 
     expect(outcomeResponse).toEqual({
       requestId: requestResponse.requestId,
@@ -398,17 +313,186 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
   })
 
   it('should respond with an invalid response message if calling the output twice', async () => {
-    const requestResponse = (await desktopHTTPClient.request({
+    const requestResponse = (await httpClient.request({
       method: METHOD_DCL_PERSONAL_SIGN,
       params: []
     })) as RequestResponseMessage
 
-    await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
+    await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
 
-    const outcomeResponse = await desktopHTTPClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
+    const outcomeResponse = await httpClient.sendSuccessfulOutcome(requestResponse.requestId, 'sender', 'result')
 
     expect(outcomeResponse).toEqual({
       error: `Request with id "${requestResponse.requestId}" already has a response`
     })
   })
 })
+
+testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
+  'when posting that a request needs validation but the request has expired',
+  args => {
+    beforeEach(async () => {
+      const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+      httpClient = await createHttpClient(port)
+    })
+
+    it('should respond with a 410 and an expired response message', async () => {
+      const requestResponse = (await httpClient.request({
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })) as RequestResponseMessage
+
+      const response = await httpClient.notifyRequestValidation(requestResponse.requestId)
+
+      expect(response).toEqual({
+        error: `Request with id "${requestResponse.requestId}" has expired`
+      })
+    })
+  }
+)
+
+test('when posting that a request needs validation but the request does not exist', args => {
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
+  })
+
+  it('should respond with a 404 and a not found response message', async () => {
+    const response = await httpClient.notifyRequestValidation('requestId')
+
+    expect(response).toEqual({
+      error: 'Request with id "requestId" not found'
+    })
+  })
+})
+
+test('when posting that a request needs validation and the request is valid', args => {
+  let requestResponse: RequestResponseMessage
+
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
+    wsClient = await createAuthWsClient(port)
+  })
+
+  describe('and there is a client connected listening for the request validation', () => {
+    beforeEach(async () => {
+      requestResponse = (await wsClient.emitWithAck('request', {
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })) as RequestResponseMessage
+    })
+
+    it('should respond with a 204 and a valid response message and send the request validation to the client', async () => {
+      const promiseOfRequestValidation = new Promise<RequestValidationMessage>((resolve, _) => {
+        wsClient.on(MessageType.REQUEST_VALIDATION, (data: RequestValidationMessage) => {
+          resolve(data)
+        })
+      })
+
+      await httpClient.notifyRequestValidation(requestResponse.requestId)
+
+      return expect(promiseOfRequestValidation).resolves.toEqual({
+        requestId: requestResponse.requestId
+      })
+    })
+  })
+
+  describe('and there is no client connected listening for the request validation', () => {
+    beforeEach(async () => {
+      requestResponse = (await httpClient.request({
+        method: METHOD_DCL_PERSONAL_SIGN,
+        params: []
+      })) as RequestResponseMessage
+    })
+
+    it('should respond with a 204 and a valid response message', async () => {
+      return expect(httpClient.notifyRequestValidation(requestResponse.requestId)).resolves.toBeUndefined()
+    })
+  })
+})
+
+// test('when getting the request validation status of a request that does not exist', args => {
+//   beforeEach(async () => {
+//     const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+//     httpClient = await createHttpClient(port)
+//   })
+
+//   it('should respond with a 404 and an error message', async () => {
+//     const response = await httpClient.getRequestValidationStatus('requestId')
+
+//     expect(response).toEqual({
+//       error: 'Request with id "requestId" not found'
+//     })
+//   })
+// })
+
+// testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
+//   'when getting the request validation status of a request that has expired',
+//   args => {
+//     let requestResponse: RequestResponseMessage
+
+//     beforeEach(async () => {
+//       const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+//       httpClient = await createHttpClient(port)
+//       requestResponse = (await httpClient.request({
+//         method: METHOD_DCL_PERSONAL_SIGN,
+//         params: []
+//       })) as RequestResponseMessage
+//     })
+
+//     it('should respond with a 410 and an expired response message', async () => {
+//       const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
+
+//       expect(response).toEqual({
+//         error: 'Request with id "requestId" has expired'
+//       })
+//     })
+//   }
+// )
+
+// test('when getting the request validation status of a request that should not be validated', args => {
+//   let requestResponse: RequestResponseMessage
+
+//   beforeEach(async () => {
+//     const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+//     httpClient = await createHttpClient(port)
+//     requestResponse = (await httpClient.request({
+//       method: METHOD_DCL_PERSONAL_SIGN,
+//       params: []
+//     })) as RequestResponseMessage
+//   })
+
+//   it('should respond with a 200 and the request validation status as false', async () => {
+//     const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
+
+//     expect(response).toEqual({
+//       requestId: requestResponse.requestId,
+//       requiresValidation: false
+//     })
+//   })
+// })
+
+// test('when getting the request validation status of a request that should be validated', args => {
+//   let requestResponse: RequestResponseMessage
+
+//   beforeEach(async () => {
+//     const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+//     httpClient = await createHttpClient(port)
+//     requestResponse = (await httpClient.request({
+//       method: METHOD_DCL_PERSONAL_SIGN,
+//       params: []
+//     })) as RequestResponseMessage
+
+//     await httpClient.notifyRequestValidation(requestResponse.requestId)
+//   })
+
+//   it('should respond with a 200 and the request validation status as true', async () => {
+//     const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
+
+//     expect(response).toEqual({
+//       requestId: requestResponse.requestId,
+//       requiresValidation: true
+//     })
+//   })
+// })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,119 @@
+import { DefaultEventsMap } from 'socket.io/dist/typed-events'
+import { io, Socket } from 'socket.io-client'
+import {
+  OutcomeResponseMessage,
+  RecoverResponseMessage,
+  RequestResponseMessage,
+  RequestValidationStatusMessage
+} from '../src/ports/server/types'
+
+export type HttpPollingClient = {
+  request(data: unknown): Promise<RequestResponseMessage | { error: string }>
+  sendSuccessfulOutcome(requestId: string, sender: string, result: unknown): Promise<{ error: string } | undefined>
+  sendFailedOutcome(requestId: string, sender: string, error: { code: number; message: string }): Promise<{ error: string } | undefined>
+  notifyRequestValidation(requestId: string): Promise<{ error: string } | undefined>
+  getRequestValidationStatus(requestId: string): Promise<RequestValidationStatusMessage | { error: string } | undefined>
+  getOutcome(requestId: string): Promise<OutcomeResponseMessage | undefined>
+  recover(requestId: string): Promise<RecoverResponseMessage>
+}
+
+export async function createHttpClient(port: number | string): Promise<HttpPollingClient> {
+  const url = `http://localhost:${port}`
+
+  return {
+    async request(data: unknown): Promise<RequestResponseMessage | { error: string }> {
+      // Make a post request
+      const response = await fetch(`${url}/requests`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: [
+          ['Content-Type', 'application/json'],
+          ['Origin', 'http://localhost:3000']
+        ]
+      })
+
+      return response.json()
+    },
+    async sendSuccessfulOutcome(requestId: string, sender: string, result: unknown): Promise<{ error: string } | undefined> {
+      const response = await fetch(`${url}/v2/requests/${requestId}/outcome`, {
+        method: 'POST',
+        body: JSON.stringify({ sender, result }),
+        headers: [['Content-Type', 'application/json']]
+      })
+      let body: { error: string } | undefined
+
+      try {
+        body = await response.json()
+      } catch (e) {
+        return undefined
+      }
+
+      return body
+    },
+    async sendFailedOutcome(
+      requestId: string,
+      sender: string,
+      error: { code: number; message: string }
+    ): Promise<{ error: string } | undefined> {
+      const response = await fetch(`${url}/v2/requests/${requestId}/outcome`, {
+        method: 'POST',
+        body: JSON.stringify({ sender, error }),
+        headers: [['Content-Type', 'application/json']]
+      })
+      let body: { error: string } | undefined
+
+      try {
+        body = await response.json()
+      } catch (e) {
+        return undefined
+      }
+
+      return body
+    },
+    async recover(requestId: string): Promise<RecoverResponseMessage> {
+      const response = await fetch(`${url}/v2/requests/${requestId}`, {
+        method: 'GET',
+        headers: [['Origin', 'http://localhost:3000']]
+      })
+
+      return response.json()
+    },
+    async getOutcome(requestId: string): Promise<OutcomeResponseMessage | undefined> {
+      const response = await fetch(`${url}/requests/${requestId}`, {
+        method: 'GET',
+        headers: [['Origin', 'http://localhost:3000']]
+      })
+
+      return response.json()
+    },
+    async notifyRequestValidation(requestId: string): Promise<{ error: string } | undefined> {
+      const result = await fetch(`${url}/v2/requests/${requestId}/validation`, {
+        method: 'POST'
+      })
+
+      if (result.ok) {
+        return undefined
+      }
+
+      return result.json()
+    },
+    async getRequestValidationStatus(requestId: string): Promise<RequestValidationStatusMessage | { error: string } | undefined> {
+      const result = await fetch(`${url}/v2/requests/${requestId}/validation`, {
+        method: 'GET'
+      })
+
+      return result.json()
+    }
+  }
+}
+
+export async function createAuthWsClient(port: number | string): Promise<Socket<DefaultEventsMap, DefaultEventsMap>> {
+  const ioClient = io(`http://localhost:${port}`)
+  return new Promise(resolve => {
+    const handleOnConnect = () => {
+      resolve(ioClient)
+    }
+
+    ioClient.on('connect', handleOnConnect)
+  })
+}


### PR DESCRIPTION
This PR adds the capability to notify that a request requires validation.
This is done using the `REQUEST_VALIDATION` message on the WS server or the `/validation` endpoint.
This PR also introduces a breaking change in the `outcomes` endpoint, which now lives under the requests domain. This is not really an issue, as this is not actually being on use.