### PR TITLE
feat: Add live health check response with timestamp #19

### DIFF
--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -13,6 +13,7 @@ import {
   HttpOutcomeMessage,
   IServerComponent,
   InvalidResponseMessage,
+  LiveResponseMessage,
   MessageType,
   OutcomeMessage,
   OutcomeResponseMessage,
@@ -405,7 +406,9 @@ export async function createServerComponent({
     })
 
     app.get('/health/live', (_req, res) => {
-      res.sendStatus(200)
+      return sendResponse<LiveResponseMessage>(res, 200, {
+        timestamp: Date.now()
+      })
     })
 
     // Wraps the callback function on messages to type the message that is being sent

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -21,6 +21,10 @@ export type RequestMessage = Request & {
   authChain?: AuthChain
 }
 
+export type LiveResponseMessage = {
+  timestamp: number
+}
+
 export type RequestResponseMessage = {
   requestId: string
   expiration: Date


### PR DESCRIPTION
Return server timestamp at `/health/live` endpoint to check user clock misconfiguration based on server clock 