### PR TITLE
fix: modify error shown on IP mismatch

### DIFF
--- a/src/ports/server/ip-utils.ts
+++ b/src/ports/server/ip-utils.ts
@@ -59,7 +59,8 @@ export const validateIpAddress = (originalIp: string, currentIp: string): { vali
     ? { valid: true }
     : {
         valid: false,
-        reason: `IP address mismatch. Original: ${originalIp}, Current: ${currentIp}`,
+        reason:
+          'We detected a sign-in from a different network. Please connect using the same Wi-Fi or mobile network you used before and try again.',
         metricReason: 'ip_mismatch'
       }
 }

--- a/test/unit/ip-utils.spec.ts
+++ b/test/unit/ip-utils.spec.ts
@@ -483,7 +483,9 @@ describe('when validating IP addresses', () => {
     it('should provide detailed mismatch message', () => {
       const result = validateIpAddress(originalIp, currentIp)
 
-      expect(result.reason).toBe('IP address mismatch. Original: 203.0.113.1, Current: 203.0.113.2')
+      expect(result.reason).toBe(
+        'We detected a sign-in from a different network. Please connect using the same Wi-Fi or mobile network you used before and try again.'
+      )
     })
 
     it('should provide ip_mismatch metric reason', () => {


### PR DESCRIPTION
Change the error message on IP mismatch to prevent mentioning the IP keyword or addresses.