### PR TITLE
feat: skip IP validation for mobile identities

### DIFF
--- a/src/ports/storage/types.ts
+++ b/src/ports/storage/types.ts
@@ -26,4 +26,5 @@ export type StorageIdentity = {
   expiration: Date
   createdAt: Date
   ipAddress: string
+  isMobile?: boolean
 }


### PR DESCRIPTION
  ## Summary
  - Add `isMobile` flag to identity storage to differentiate mobile from desktop auth flows
  - Skip IP validation on identity retrieval when `isMobile` is true (mobile webview and native app send
  requests from different IPs)
  - Add comprehensive IP header logging for debugging mobile IP mismatches