### PR TITLE
feat: onboarding redesign — download-first funnel (3 CPs, 2 nudges)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -47,3 +47,9 @@ ONBOARDING_ADMIN_ENABLED=false
 # Slack notifications for nudge emails (optional — no messages sent if unset)
 # SLACK_BOT_TOKEN=dummy-token
 SLACK_NUDGE_CHANNEL=onboarding-nudges-sent
+
+# Analytics (Segment via DCL analytics proxy) — server-side tracking of nudge sends
+# Leave ANALYTICS_API_TOKEN empty in dev to disable forwarding.
+ANALYTICS_CONTEXT="auth-server"
+ANALYTICS_API_URL=""
+ANALYTICS_API_TOKEN=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "auth-server",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dcl/analytics-component": "^0.2.5",
         "@dcl/crypto": "^3.4.5",
         "@dcl/job-component": "^0.2.8",
         "@dcl/memory-cache-component": "^2.2.2",
@@ -642,6 +643,23 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dcl/analytics-component": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@dcl/analytics-component/-/analytics-component-0.2.8.tgz",
+      "integrity": "sha512-e55KI49jGs3/Gdvx+48TF/aGP63rqP2Q6AfP6DLV29ypFyg+fyTPhbntyVeyc4fpDsNwe9GoDIklrIOe/XfP9A==",
+      "dependencies": {
+        "@dcl/core-commons": "0.6.0",
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
+    "node_modules/@dcl/analytics-component/node_modules/@dcl/core-commons": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.6.0.tgz",
+      "integrity": "sha512-t7+Q+oZcj8PKjvP0iQXkjnK5+pNCNUpBcEFP+V0Lcurl3DdndI7sOsYPIzkxhdjFgOfcaT9SdgFD/LxmjwA3Tg==",
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
       }
     },
     "node_modules/@dcl/core-commons": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@dcl/analytics-component": "^0.2.5",
     "@dcl/crypto": "^3.4.5",
     "@dcl/job-component": "^0.2.8",
     "@dcl/memory-cache-component": "^2.2.2",

--- a/src/components.ts
+++ b/src/components.ts
@@ -4,6 +4,7 @@ import { createFetchComponent } from '@well-known-components/fetch-component'
 import { createLogComponent } from '@well-known-components/logger'
 import { createMetricsComponent } from '@well-known-components/metrics'
 import { createTracerComponent } from '@well-known-components/tracer-component'
+import { createAnalyticsComponent } from '@dcl/analytics-component'
 import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
 import { createRedisComponent } from '@dcl/redis-component'
 import { createSlackComponent } from '@dcl/slack-component'
@@ -16,6 +17,7 @@ import { createOnboardingComponent } from './ports/onboarding/component'
 import { createServerComponent } from './ports/server/component'
 import { createStorageComponent } from './ports/storage/component'
 import { AppComponents } from './types'
+import { AnalyticsEventPayload } from './types/analytics'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -35,11 +37,12 @@ export async function initComponents(): Promise<AppComponents> {
     (await config.getString('SERVICE_BASE_URL')) || 'https://auth-api.decentraland.org'
   )
   const featureFlags = createFeatureFlagsAdapter({ logs, features })
+  const analytics = await createAnalyticsComponent<AnalyticsEventPayload>({ config, logs, fetcher: fetch })
   const onboarding = createOnboardingComponent({ db, logs })
   const email = await createEmailComponent({ config, logs })
   const slackToken = await config.getString('SLACK_BOT_TOKEN')
   const slack = createSlackComponent({ logs }, { token: slackToken ?? '' })
-  const nudgeJob = createNudgeJobComponent({ onboarding, email, slack, logs, config, featureFlags })
+  const nudgeJob = createNudgeJobComponent({ onboarding, email, slack, logs, config, featureFlags, analytics, db })
   const server = await createServerComponent({
     config,
     logs,
@@ -54,6 +57,7 @@ export async function initComponents(): Promise<AppComponents> {
   })
 
   return {
+    analytics,
     cache,
     config,
     fetch,

--- a/src/migrations/1777795200000_onboarding_redesign_download_first.ts
+++ b/src/migrations/1777795200000_onboarding_redesign_download_first.ts
@@ -2,7 +2,23 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
 
 export const shorthands: ColumnDefinitions | undefined = undefined
 
+/**
+ * IMPORTANT: this migration must run BEFORE the new app code is deployed.
+ * The new code emits/accepts `id_type='anon'` and `checkpointId ∈ {1,2,3}`,
+ * which the old constraints reject.
+ *
+ * Also: the legacy data cleanup MUST happen before the new CHECK constraints
+ * are added. PostgreSQL validates all existing rows when ADD CONSTRAINT runs,
+ * so adding `checkpoint BETWEEN 1 AND 3` while CP4..7 rows still exist would
+ * abort the migration.
+ */
 export function up(pgm: MigrationBuilder): void {
+  // 1) Cleanup legacy rows BEFORE tightening constraints (otherwise ADD CHECK
+  //    would scan existing rows and fail).
+  pgm.sql('DELETE FROM email_nudges WHERE sequence = 3 OR checkpoint > 3')
+  pgm.sql('DELETE FROM onboarding_checkpoints WHERE checkpoint > 3')
+
+  // 2) Replace constraints with the new tight ones.
   pgm.dropConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check')
   pgm.addConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check', {
     check: 'checkpoint BETWEEN 1 AND 3'
@@ -18,15 +34,25 @@ export function up(pgm: MigrationBuilder): void {
     check: 'sequence IN (1, 2)'
   })
 
-  pgm.sql('DELETE FROM email_nudges WHERE sequence = 3 OR checkpoint > 3')
-  pgm.sql('DELETE FROM onboarding_checkpoints WHERE checkpoint > 3')
-
+  // 3) Partial covering index that satisfies the nudge query as an index-only
+  //    scan (returns user_id + email without touching the heap).
   pgm.createIndex('onboarding_checkpoints', ['completed_at'], {
     name: 'idx_oc_cp2_completed_with_email',
-    where: 'checkpoint = 2 AND email IS NOT NULL AND completed_at IS NOT NULL'
+    where: 'checkpoint = 2 AND email IS NOT NULL AND completed_at IS NOT NULL',
+    include: ['user_id', 'email']
   })
 }
 
+/**
+ * ⚠️ DATA LOSS WARNING ⚠️
+ *
+ * Running `down()` does NOT restore the rows deleted by `up()`. Legacy
+ * checkpoints (CP4..CP7) and nudges with sequence 3 are unrecoverable —
+ * if you need them back, restore from a backup taken before `up()` ran.
+ *
+ * The constraints are restored to their pre-redesign shape so the table
+ * structure is technically reversible, but the data is not.
+ */
 export function down(pgm: MigrationBuilder): void {
   pgm.dropIndex('onboarding_checkpoints', ['completed_at'], {
     name: 'idx_oc_cp2_completed_with_email'

--- a/src/migrations/1777795200000_onboarding_redesign_download_first.ts
+++ b/src/migrations/1777795200000_onboarding_redesign_download_first.ts
@@ -1,0 +1,49 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.dropConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check')
+  pgm.addConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check', {
+    check: 'checkpoint BETWEEN 1 AND 3'
+  })
+
+  pgm.dropConstraint('onboarding_checkpoints', 'onboarding_checkpoints_id_type_check')
+  pgm.addConstraint('onboarding_checkpoints', 'onboarding_checkpoints_id_type_check', {
+    check: "id_type IN ('anon', 'email', 'wallet')"
+  })
+
+  pgm.dropConstraint('email_nudges', 'email_nudges_sequence_check')
+  pgm.addConstraint('email_nudges', 'email_nudges_sequence_check', {
+    check: 'sequence IN (1, 2)'
+  })
+
+  pgm.sql('DELETE FROM email_nudges WHERE sequence = 3 OR checkpoint > 3')
+  pgm.sql('DELETE FROM onboarding_checkpoints WHERE checkpoint > 3')
+
+  pgm.createIndex('onboarding_checkpoints', ['completed_at'], {
+    name: 'idx_oc_cp2_completed_with_email',
+    where: 'checkpoint = 2 AND email IS NOT NULL AND completed_at IS NOT NULL'
+  })
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('onboarding_checkpoints', ['completed_at'], {
+    name: 'idx_oc_cp2_completed_with_email'
+  })
+
+  pgm.dropConstraint('email_nudges', 'email_nudges_sequence_check')
+  pgm.addConstraint('email_nudges', 'email_nudges_sequence_check', {
+    check: 'sequence IN (1, 2, 3)'
+  })
+
+  pgm.dropConstraint('onboarding_checkpoints', 'onboarding_checkpoints_id_type_check')
+  pgm.addConstraint('onboarding_checkpoints', 'onboarding_checkpoints_id_type_check', {
+    check: "id_type IN ('email', 'wallet')"
+  })
+
+  pgm.dropConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check')
+  pgm.addConstraint('onboarding_checkpoints', 'onboarding_checkpoints_checkpoint_check', {
+    check: 'checkpoint BETWEEN 1 AND 7'
+  })
+}

--- a/src/ports/email/component.ts
+++ b/src/ports/email/component.ts
@@ -93,9 +93,7 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
       logger.log(`[TO:${to}][SEQ:${sequence}] Nudge email sent. Message ID: ${messageId}`)
       return messageId
     } catch (e) {
-      logger.error(
-        `[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
-      )
+      logger.error(`[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
       return undefined
     }
   }

--- a/src/ports/email/component.ts
+++ b/src/ports/email/component.ts
@@ -4,277 +4,52 @@ import { AppComponents } from '../../types'
 import { IEmailComponent, SendNudgeParams } from './types'
 
 // ---------------------------------------------------------------------------
-// Per-checkpoint, per-sequence nudge email content
+// Per-sequence nudge email content (CP2 = authenticated, no CP3 yet)
 // ---------------------------------------------------------------------------
 
 type NudgeContent = {
   subject: string
   preheader: string
-  heading: string // HTML — use <br> for line breaks, <span class="gradient-text"> for highlighted words
-  body: string // HTML paragraphs
+  heading: string
+  body: string
   buttonText: string
   buttonUrl: string
   tagline: string
 }
 
-// Helper: wraps text in a gradient span (orange→red, falls back to #FF2D55 in Outlook)
 const g = (text: string): string => `<span class="gradient-text">${text}</span>`
 
-function seqMap(seq1: NudgeContent, seq2: NudgeContent, seq3: NudgeContent): Map<number, NudgeContent> {
-  return new Map([
-    [1, seq1],
-    [2, seq2],
-    [3, seq3]
-  ])
-}
-
-// prettier-ignore
-const NUDGE_CONTENT = new Map<number, Map<number, NudgeContent>>([
-
-  // ── CP2 — Auth Method Selected ────────────────────────────────────────────
-  [2, seqMap(
+const NUDGE_CONTENT = new Map<number, NudgeContent>([
+  [
+    1,
     {
-      subject: 'Trouble Signing In?',
-      preheader: 'You started, but something may have interrupted the process.',
-      heading: `You started ${g('signing in,')}<br>but something cut the process short.`,
+      subject: 'Your Decentraland account is ready — jump in',
+      preheader: 'Open Decentraland and continue where you left off.',
+      heading: `Your account is ${g('ready.')}<br>Time to step in.`,
       body:
-        '<p style="margin:0 0 14px 0;">That happens. A window might not have opened.</p>' +
-        '<p style="margin:0;">You can pick up where you left off and continue signing up.</p>',
-      buttonText: 'Continue Sign Up',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: 'One step gets you in.'
-    },
-    {
-      subject: "You're Getting Closer",
-      preheader: "Finish signing in and choose how you'll appear in Decentraland.",
-      heading: `You're one step away<br>from ${g('choosing your name.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Once the sign up finishes, the next step is creating your username.</p>' +
-        '<p style="margin:0 0 14px 0;">This is the name people will see when you explore places, join events, or run into someone in Decentraland.</p>' +
-        '<p style="margin:0;">You can always change how you show up later. Right now, all you need to do is finish signing in.</p>',
-      buttonText: 'Continue Sign Up',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: 'One step gets you in.'
-    },
-    {
-      subject: 'The World Is Already Active',
-      preheader: 'Events, games, and people are waiting inside.',
-      heading: `The world is ${g('already active.')}`,
-      body:
-        "<p style=\"margin:0 0 14px 0;\">Decentraland isn't just something you set up\u2014it's a place you drop into.</p>" +
-        '<p style="margin:0 0 14px 0;">Events are happening. Games are running. People are exploring together.</p>' +
-        '<p style="margin:0;">You were close to entering. Finish signing in and come hang out.</p>',
-      buttonText: 'Continue Sign Up',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
+        '<p style="margin:0 0 14px 0;">You finished signing in but haven\'t entered the world yet.</p>' +
+        '<p style="margin:0 0 14px 0;">Decentraland is a place you actually move through. Events are happening, people are exploring, and your avatar is waiting.</p>' +
+        '<p style="margin:0;">Open Decentraland and continue.</p>',
+      buttonText: 'Open Decentraland',
+      buttonUrl: 'https://decentraland.org/download',
       tagline: 'One step gets you in.'
     }
-  )],
-
-  // ── CP3 — Profile Creation ────────────────────────────────────────────────
-  [3, seqMap(
+  ],
+  [
+    2,
     {
-      subject: 'Finish Choosing Your Name',
-      preheader: "You started creating your profile but didn't finish.",
-      heading: `You were ${g('choosing your name,')} but didn't finish.`,
+      subject: 'Still want to explore? The world is live',
+      preheader: 'Open Decentraland and join everyone inside.',
+      heading: `Something is ${g('happening right now.')}`,
       body:
-        '<p style="margin:0 0 14px 0;">Your username is how people recognize you in Decentraland.</p>' +
-        '<p style="margin:0 0 14px 0;">It appears above your avatar when you talk, explore places, or run into someone again later.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">It doesn't need to be perfect. Most people change things once they've spent time inside.</p>" +
-        '<p style="margin:0;">Right now, just pick something that gets you through the door.</p>',
-      buttonText: 'Continue Profile Setup',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: 'Your name is your first impression.'
-    },
-    {
-      subject: 'Your Name Is How People Find You',
-      preheader: 'Finish creating your profile to continue.',
-      heading: `Choose how ${g("you'll appear.")}`,
-      body:
-        '<p style="margin:0 0 14px 0;">In Decentraland, your username is how people recognize you.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">It's what appears when you speak, explore places, or return somewhere later and see familiar faces.</p>" +
-        '<p style="margin:0 0 14px 0;">Choose something that feels like you for now. You can always change it later.</p>' +
-        "<p style=\"margin:0;\">Once that's done, you'll move on to creating your avatar.</p>",
-      buttonText: 'Continue Profile Setup',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: 'Your name is your first impression.'
-    },
-    {
-      subject: 'People Remember Names',
-      preheader: 'Finish creating your profile and step inside.',
-      heading: `People remember ${g('who they meet here.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Decentraland is a place where people run into each other.</p>' +
-        '<p style="margin:0 0 14px 0;">You recognize avatars. You recognize names. Over time, you start to notice familiar faces.</p>' +
-        '<p style="margin:0 0 14px 0;">That all begins with choosing your name.</p>' +
-        '<p style="margin:0;">Finish setting up your profile and continue inside.</p>',
-      buttonText: 'Continue Profile Setup',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: 'Your name is your first impression.'
-    }
-  )],
-
-  // ── CP4 — Avatar Creator ──────────────────────────────────────────────────
-  [4, seqMap(
-    {
-      subject: 'Your Avatar Is Almost Ready',
-      preheader: "You started creating it but didn't finish.",
-      heading: `Your avatar is ${g('waiting')}<br>to be finished.`,
-      body:
-        "<p style=\"margin:0 0 14px 0;\">You started creating your avatar but didn't complete it.</p>" +
-        '<p style="margin:0 0 14px 0;">That\'s normal. This part can feel bigger than it is.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">Your first avatar doesn't have to be perfect. Many people change how they look later after they've spent time exploring.</p>" +
-        '<p style="margin:0;">For now, just choose something that gets you into your first hangout.</p>',
-      buttonText: 'Finish Your Avatar',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: "You're closer than you think."
-    },
-    {
-      subject: 'This Is How People Recognize You',
-      preheader: 'Finish your avatar and continue.',
-      heading: `This is how ${g('you show up.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Your avatar is how people recognize you when you move through Decentraland.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">Clothes, colors, style\u2014it's all flexible. You can change it anytime.</p>" +
-        '<p style="margin:0 0 14px 0;">Right now, all you need is a starting point.</p>' +
-        '<p style="margin:0;">Finish your avatar and continue.</p>',
-      buttonText: 'Finish Your Avatar',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: "You're closer than you think."
-    },
-    {
-      subject: 'People Remember Who They Meet Here',
-      preheader: 'Finish your avatar and join in.',
-      heading: `Familiar faces ${g('appear over time.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Spend enough time in Decentraland and something interesting happens.</p>' +
-        '<p style="margin:0 0 14px 0;">You start recognizing people. Someone remembers you from a place you visited earlier.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">That's how communities form.</p>" +
-        '<p style="margin:0;">Finish creating your avatar and step in.</p>',
-      buttonText: 'Finish Your Avatar',
-      buttonUrl: 'https://decentraland.org/auth/login',
-
-      tagline: "You're closer than you think."
-    }
-  )],
-
-  // ── CP5 — Download Page Viewed ────────────────────────────────────────────
-  [5, seqMap(
-    {
-      subject: 'One Step Left To Enter',
-      preheader: 'Download Decentraland to continue.',
-      heading: `You're ${g('almost there.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">You reached the point where Decentraland moves from the browser into a place you can actually move around.</p>' +
-        '<p style="margin:0 0 14px 0;">To continue, you just need to download the desktop app.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">Once it's installed, you'll be able to enter anytime without setting things up again.</p>" +
-        '<p style="margin:0;">Download Decentraland and continue.</p>',
-      buttonText: 'Download Decentraland',
+        '<p style="margin:0 0 14px 0;">Decentraland isn\'t just an account you set up — it\'s a place you show up.</p>' +
+        '<p style="margin:0 0 14px 0;">Events are running. Conversations are starting. People are exploring together.</p>' +
+        '<p style="margin:0;">You\'re one step away from joining them.</p>',
+      buttonText: 'Open Decentraland',
       buttonUrl: 'https://decentraland.org/download',
-
-      tagline: 'The world is waiting.'
-    },
-    {
-      subject: 'Download Once, Enter Anytime',
-      preheader: 'Install Decentraland and continue.',
-      heading: `This is the step that ${g('opens everything.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Downloading Decentraland lets you move through places in real time.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">You'll see other people moving around you, conversations happening, and events taking place.</p>" +
-        '<p style="margin:0 0 14px 0;">Once the app is installed, entering becomes as simple as opening it.</p>' +
-        '<p style="margin:0;">Download Decentraland and continue.</p>',
-      buttonText: 'Download Decentraland',
-      buttonUrl: 'https://decentraland.org/download',
-
-      tagline: 'The world is waiting.'
-    },
-    {
-      subject: 'People Are Already There',
-      preheader: 'Install Decentraland and step inside.',
-      heading: `Something might be ${g('happening right now.')}`,
-      body:
-        "<p style=\"margin:0 0 14px 0;\">Decentraland isn't just something you set up. It's somewhere you show up.</p>" +
-        '<p style="margin:0 0 14px 0;">Events happen. Conversations start. Crowds gather.</p>' +
-        '<p style="margin:0;">Downloading the app is the step that lets you join in.</p>',
-      buttonText: 'Download Decentraland',
-      buttonUrl: 'https://decentraland.org/download',
-
       tagline: 'The world is waiting.'
     }
-  )],
-
-  // ── CP6 — Download Clicked ────────────────────────────────────────────────
-  [6, seqMap(
-    {
-      subject: 'Almost Installed',
-      preheader: 'Just open the file you downloaded.',
-      heading: `You already ${g('downloaded')}<br>Decentraland.`,
-      body:
-        '<p style="margin:0 0 14px 0;">The last step is opening the file that was downloaded.</p>' +
-        '<p style="margin:0 0 14px 0;">Look in your browser\'s recent downloads or your Downloads folder and double-click the Decentraland file.</p>' +
-        '<p style="margin:0;">The installer will open and finish the rest automatically.</p>',
-      buttonText: 'Resume Installation',
-      buttonUrl: 'https://decentraland.org/download',
-
-      tagline: 'Almost there.'
-    },
-    {
-      subject: 'One Small Step Left',
-      preheader: 'Open the installer to finish setting things up.',
-      heading: `Installation takes ${g('just a moment.')}`,
-      body:
-        "<p style=\"margin:0 0 14px 0;\">If Decentraland hasn't opened yet, the installer may still be waiting in your downloads.</p>" +
-        '<p style="margin:0 0 14px 0;">Open the file you downloaded earlier and the launcher will take it from there.</p>' +
-        "<p style=\"margin:0;\">Once it finishes, Decentraland will open and you'll be ready to continue.</p>",
-      buttonText: 'Resume Installation',
-      buttonUrl: 'https://decentraland.org/download',
-
-      tagline: 'Almost there.'
-    },
-    {
-      subject: "You're Right At The Threshold",
-      preheader: 'Open the installer and step inside.',
-      heading: `You're ${g('almost in.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Decentraland is already on your computer.</p>' +
-        "<p style=\"margin:0 0 14px 0;\">All that's left is opening the installer you downloaded earlier.</p>" +
-        "<p style=\"margin:0;\">Once it runs, the launcher will open and you'll be ready to join everyone inside.</p>",
-      buttonText: 'Resume Installation',
-      buttonUrl: 'https://decentraland.org/download',
-
-      tagline: 'Almost there.'
-    }
-  )]
-])
-
-// Fallback for checkpoints without specific content (CP1, CP7)
-// prettier-ignore
-const FALLBACK_CHECKPOINT_NAMES = new Map<number, string>([
-  [1, 'Authentication Started'],
-  [2, 'Auth Method Selected'],
-  [3, 'Profile Creation'],
-  [4, 'Avatar Creator Started'],
-  [5, 'Download Page Viewed'],
-  [6, 'Download Clicked'],
-  [7, 'Launcher Ready']
-])
-
-// prettier-ignore
-const FALLBACK_CTA_URLS = new Map<number, string>([
-  [1, 'https://decentraland.org/auth/login'],
-  [2, 'https://decentraland.org/auth/login'],
-  [3, 'https://decentraland.org/auth/login'],
-  [4, 'https://decentraland.org/auth/login'],
-  [5, 'https://decentraland.org/download'],
-  [6, 'https://decentraland.org/download'],
-  [7, 'decentraland://']
+  ]
 ])
 
 export async function createEmailComponent({ config, logs }: Pick<AppComponents, 'config' | 'logs'>): Promise<IEmailComponent> {
@@ -287,33 +62,23 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
   sgMail.setApiKey(apiKey)
 
   const sendNudge = async (params: SendNudgeParams): Promise<string | undefined> => {
-    const { to, checkpointId, sequence } = params
+    const { to, sequence } = params
 
-    const content = NUDGE_CONTENT.get(checkpointId)?.get(sequence)
-    const cpName = FALLBACK_CHECKPOINT_NAMES.get(checkpointId) ?? `Checkpoint ${checkpointId}`
+    const content = NUDGE_CONTENT.get(sequence)
+    if (!content) {
+      logger.error(`[TO:${to}][SEQ:${sequence}] No nudge content for sequence`)
+      return undefined
+    }
 
-    const dynamicTemplateData = content
-      ? {
-          subject: content.subject,
-          preheader: content.preheader,
-          heading: content.heading,
-          body: content.body,
-          buttonText: content.buttonText,
-          buttonUrl: content.buttonUrl,
-          checkpointId,
-          tagline: content.tagline
-        }
-      : {
-          // Fallback for unmapped checkpoints
-          subject: 'Continue your Decentraland setup',
-          preheader: `You were on the ${cpName} step.`,
-          heading: "You're almost there.",
-          body: '<p style="margin:0;">You were in the middle of setting up your Decentraland account. Pick up where you left off.</p>',
-          buttonText: 'Continue',
-          buttonUrl: FALLBACK_CTA_URLS.get(checkpointId) ?? 'https://decentraland.org',
-          checkpointId,
-          tagline: "You're closer than you think."
-        }
+    const dynamicTemplateData = {
+      subject: content.subject,
+      preheader: content.preheader,
+      heading: content.heading,
+      body: content.body,
+      buttonText: content.buttonText,
+      buttonUrl: content.buttonUrl,
+      tagline: content.tagline
+    }
 
     const msg: sgMail.MailDataRequired = {
       to,
@@ -325,11 +90,11 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
     try {
       const [response] = await sgMail.send(msg)
       const messageId = response.headers['x-message-id']
-      logger.log(`[CP:${checkpointId}][TO:${to}][SEQ:${sequence}] Nudge email sent. Message ID: ${messageId}`)
+      logger.log(`[TO:${to}][SEQ:${sequence}] Nudge email sent. Message ID: ${messageId}`)
       return messageId
     } catch (e) {
       logger.error(
-        `[CP:${checkpointId}][TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
+        `[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
       )
       return undefined
     }

--- a/src/ports/email/component.ts
+++ b/src/ports/email/component.ts
@@ -19,38 +19,36 @@ type NudgeContent = {
 
 const g = (text: string): string => `<span class="gradient-text">${text}</span>`
 
-const NUDGE_CONTENT = new Map<number, NudgeContent>([
-  [
-    1,
-    {
-      subject: 'Your Decentraland account is ready — jump in',
-      preheader: 'Open Decentraland and continue where you left off.',
-      heading: `Your account is ${g('ready.')}<br>Time to step in.`,
-      body:
-        '<p style="margin:0 0 14px 0;">You finished signing in but haven\'t entered the world yet.</p>' +
-        '<p style="margin:0 0 14px 0;">Decentraland is a place you actually move through. Events are happening, people are exploring, and your avatar is waiting.</p>' +
-        '<p style="margin:0;">Open Decentraland and continue.</p>',
-      buttonText: 'Open Decentraland',
-      buttonUrl: 'https://decentraland.org/download',
-      tagline: 'One step gets you in.'
-    }
-  ],
-  [
-    2,
-    {
-      subject: 'Still want to explore? The world is live',
-      preheader: 'Open Decentraland and join everyone inside.',
-      heading: `Something is ${g('happening right now.')}`,
-      body:
-        '<p style="margin:0 0 14px 0;">Decentraland isn\'t just an account you set up — it\'s a place you show up.</p>' +
-        '<p style="margin:0 0 14px 0;">Events are running. Conversations are starting. People are exploring together.</p>' +
-        '<p style="margin:0;">You\'re one step away from joining them.</p>',
-      buttonText: 'Open Decentraland',
-      buttonUrl: 'https://decentraland.org/download',
-      tagline: 'The world is waiting.'
-    }
-  ]
-])
+// Record keyed by the discriminated `sequence` literal — TypeScript guarantees
+// every valid sequence has content, so callers don't need a runtime guard.
+/* eslint-disable @typescript-eslint/naming-convention */
+const NUDGE_CONTENT: Record<1 | 2, NudgeContent> = {
+  1: {
+    subject: 'Your Decentraland account is ready — jump in',
+    preheader: 'Open Decentraland and continue where you left off.',
+    heading: `Your account is ${g('ready.')}<br>Time to step in.`,
+    body:
+      '<p style="margin:0 0 14px 0;">You finished signing in but haven\'t entered the world yet.</p>' +
+      '<p style="margin:0 0 14px 0;">Decentraland is a place you actually move through. Events are happening, people are exploring, and your avatar is waiting.</p>' +
+      '<p style="margin:0;">Open Decentraland and continue.</p>',
+    buttonText: 'Open Decentraland',
+    buttonUrl: 'https://decentraland.org/download',
+    tagline: 'One step gets you in.'
+  },
+  2: {
+    subject: 'Still want to explore? The world is live',
+    preheader: 'Open Decentraland and join everyone inside.',
+    heading: `Something is ${g('happening right now.')}`,
+    body:
+      '<p style="margin:0 0 14px 0;">Decentraland isn\'t just an account you set up — it\'s a place you show up.</p>' +
+      '<p style="margin:0 0 14px 0;">Events are running. Conversations are starting. People are exploring together.</p>' +
+      '<p style="margin:0;">You\'re one step away from joining them.</p>',
+    buttonText: 'Open Decentraland',
+    buttonUrl: 'https://decentraland.org/download',
+    tagline: 'The world is waiting.'
+  }
+}
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export async function createEmailComponent({ config, logs }: Pick<AppComponents, 'config' | 'logs'>): Promise<IEmailComponent> {
   const logger = logs.getLogger('email-component')
@@ -64,12 +62,7 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
   const sendNudge = async (params: SendNudgeParams): Promise<SendNudgeResult> => {
     const { to, sequence } = params
 
-    const content = NUDGE_CONTENT.get(sequence)
-    if (!content) {
-      const error = `No nudge content for sequence ${sequence}`
-      logger.error(`[TO:${to}][SEQ:${sequence}] ${error}`)
-      return { templateId, error }
-    }
+    const content = NUDGE_CONTENT[sequence]
 
     const dynamicTemplateData = {
       subject: content.subject,
@@ -91,12 +84,17 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
     try {
       const [response] = await sgMail.send(msg)
       const messageId = response.headers['x-message-id']
+      if (!messageId) {
+        const error = 'SendGrid returned no message id'
+        logger.error(`[TO:${to}][SEQ:${sequence}] ${error}`)
+        return { ok: false, templateId, error }
+      }
       logger.log(`[TO:${to}][SEQ:${sequence}] Nudge email sent. Message ID: ${messageId}`)
-      return { templateId, messageId }
+      return { ok: true, templateId, messageId }
     } catch (e) {
       const error = isErrorWithMessage(e) ? e.message : 'Unknown error'
       logger.error(`[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${error}`)
-      return { templateId, error }
+      return { ok: false, templateId, error }
     }
   }
 

--- a/src/ports/email/component.ts
+++ b/src/ports/email/component.ts
@@ -1,7 +1,7 @@
 import sgMail from '@sendgrid/mail'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { AppComponents } from '../../types'
-import { IEmailComponent, SendNudgeParams } from './types'
+import { IEmailComponent, SendNudgeParams, SendNudgeResult } from './types'
 
 // ---------------------------------------------------------------------------
 // Per-sequence nudge email content (CP2 = authenticated, no CP3 yet)
@@ -61,13 +61,14 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
 
   sgMail.setApiKey(apiKey)
 
-  const sendNudge = async (params: SendNudgeParams): Promise<string | undefined> => {
+  const sendNudge = async (params: SendNudgeParams): Promise<SendNudgeResult> => {
     const { to, sequence } = params
 
     const content = NUDGE_CONTENT.get(sequence)
     if (!content) {
-      logger.error(`[TO:${to}][SEQ:${sequence}] No nudge content for sequence`)
-      return undefined
+      const error = `No nudge content for sequence ${sequence}`
+      logger.error(`[TO:${to}][SEQ:${sequence}] ${error}`)
+      return { templateId, error }
     }
 
     const dynamicTemplateData = {
@@ -91,10 +92,11 @@ export async function createEmailComponent({ config, logs }: Pick<AppComponents,
       const [response] = await sgMail.send(msg)
       const messageId = response.headers['x-message-id']
       logger.log(`[TO:${to}][SEQ:${sequence}] Nudge email sent. Message ID: ${messageId}`)
-      return messageId
+      return { templateId, messageId }
     } catch (e) {
-      logger.error(`[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
-      return undefined
+      const error = isErrorWithMessage(e) ? e.message : 'Unknown error'
+      logger.error(`[TO:${to}][SEQ:${sequence}] Failed to send nudge email: ${error}`)
+      return { templateId, error }
     }
   }
 

--- a/src/ports/email/types.ts
+++ b/src/ports/email/types.ts
@@ -2,8 +2,7 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 
 export type SendNudgeParams = {
   to: string
-  checkpointId: number
-  sequence: 1 | 2 | 3
+  sequence: 1 | 2
   metadata?: Record<string, unknown>
 }
 

--- a/src/ports/email/types.ts
+++ b/src/ports/email/types.ts
@@ -3,14 +3,14 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 export type SendNudgeParams = {
   to: string
   sequence: 1 | 2
-  metadata?: Record<string, unknown>
 }
 
-export type SendNudgeResult = {
-  templateId: string
-  messageId?: string
-  error?: string
-}
+/**
+ * Discriminated union: either the send succeeded (and we have a SendGrid
+ * messageId) or it failed (and we have a non-empty error message). The two
+ * states are mutually exclusive — `ok` discriminates them at the type level.
+ */
+export type SendNudgeResult = { ok: true; templateId: string; messageId: string } | { ok: false; templateId: string; error: string }
 
 export type IEmailComponent = IBaseComponent & {
   sendNudge(params: SendNudgeParams): Promise<SendNudgeResult>

--- a/src/ports/email/types.ts
+++ b/src/ports/email/types.ts
@@ -6,6 +6,12 @@ export type SendNudgeParams = {
   metadata?: Record<string, unknown>
 }
 
+export type SendNudgeResult = {
+  templateId: string
+  messageId?: string
+  error?: string
+}
+
 export type IEmailComponent = IBaseComponent & {
-  sendNudge(params: SendNudgeParams): Promise<string | undefined>
+  sendNudge(params: SendNudgeParams): Promise<SendNudgeResult>
 }

--- a/src/ports/nudge-job/component.ts
+++ b/src/ports/nudge-job/component.ts
@@ -1,5 +1,5 @@
-import { createJobComponent } from '@dcl/job-component'
 import SQL from 'sql-template-strings'
+import { createJobComponent } from '@dcl/job-component'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { AppComponents } from '../../types'
 import { AnalyticsEvent } from '../../types/analytics'
@@ -52,9 +52,7 @@ export function createNudgeJobComponent({
    */
   const tryAcquireLock = async (): Promise<boolean> => {
     try {
-      const result = await db.query<{ acquired: boolean }>(
-        SQL`SELECT pg_try_advisory_lock(${NUDGE_JOB_LOCK_ID}) AS acquired`
-      )
+      const result = await db.query<{ acquired: boolean }>(SQL`SELECT pg_try_advisory_lock(${NUDGE_JOB_LOCK_ID}) AS acquired`)
       return result.rows[0]?.acquired === true
     } catch (e) {
       logger.error(`Failed to acquire nudge-job advisory lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)

--- a/src/ports/nudge-job/component.ts
+++ b/src/ports/nudge-job/component.ts
@@ -23,14 +23,14 @@ export function createNudgeJobComponent({
     return slackChannel || undefined
   }
 
-  const notifySlack = async (nudge: { userId: string; checkpointId: number; email: string }, sequence: number): Promise<void> => {
+  const notifySlack = async (nudge: { userId: string; email: string }, sequence: 1 | 2): Promise<void> => {
     const channel = await getSlackChannel()
     if (!channel) return
 
     try {
       await slack.sendMessage({
         channel,
-        text: `Onboarding nudge sent — user stuck at CP${nudge.checkpointId}, sending nudge email seq ${sequence} to ${nudge.email}`
+        text: `Onboarding nudge sent — user authenticated but not in-world, sending nudge email seq ${sequence} to ${nudge.email}`
       })
     } catch (e) {
       logger.warn(`Failed to send Slack notification: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
@@ -47,7 +47,7 @@ export function createNudgeJobComponent({
 
     logger.log('Running nudge evaluator...', whitelist ? { whitelist: whitelist.join(', ') } : {})
 
-    for (const sequence of [1, 2, 3] as const) {
+    for (const sequence of [1, 2] as const) {
       let pendingNudges
       try {
         pendingNudges = await onboarding.getPendingNudges(sequence)
@@ -56,7 +56,6 @@ export function createNudgeJobComponent({
         continue
       }
 
-      // If whitelist is set, only send to whitelisted emails
       if (whitelist) {
         pendingNudges = pendingNudges.filter(n => whitelist.includes(n.email.toLowerCase()))
       }
@@ -67,19 +66,17 @@ export function createNudgeJobComponent({
         try {
           const messageId = await email.sendNudge({
             to: nudge.email,
-            checkpointId: nudge.checkpointId,
             sequence
           })
 
-          await onboarding.markNudgeSent(nudge.userId, nudge.checkpointId, sequence, messageId)
+          await onboarding.markNudgeSent(nudge.userId, sequence, messageId)
           void notifySlack(nudge, sequence)
         } catch (e) {
           logger.error(
-            `[CP:${nudge.checkpointId}][USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${
+            `[USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${
               isErrorWithMessage(e) ? e.message : 'Unknown error'
             }`
           )
-          // Continue processing remaining nudges even if one fails
         }
       }
     }

--- a/src/ports/nudge-job/component.ts
+++ b/src/ports/nudge-job/component.ts
@@ -1,9 +1,15 @@
 import { createJobComponent } from '@dcl/job-component'
+import SQL from 'sql-template-strings'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { AppComponents } from '../../types'
+import { AnalyticsEvent } from '../../types/analytics'
 import { INudgeJobComponent } from './types'
 
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000
+
+// Stable lock id chosen so it doesn't collide with other advisory locks the
+// app might use. Picked from a generated random int32 — keep it constant.
+const NUDGE_JOB_LOCK_ID = 731923741
 
 export function createNudgeJobComponent({
   onboarding,
@@ -11,8 +17,10 @@ export function createNudgeJobComponent({
   slack,
   logs,
   config,
-  featureFlags
-}: Pick<AppComponents, 'onboarding' | 'email' | 'slack' | 'logs' | 'config' | 'featureFlags'>): INudgeJobComponent {
+  featureFlags,
+  analytics,
+  db
+}: Pick<AppComponents, 'onboarding' | 'email' | 'slack' | 'logs' | 'config' | 'featureFlags' | 'analytics' | 'db'>): INudgeJobComponent {
   const logger = logs.getLogger('nudge-job')
 
   let slackChannel: string | undefined
@@ -37,49 +45,105 @@ export function createNudgeJobComponent({
     }
   }
 
+  /**
+   * Postgres advisory lock. Returns true if the lock was acquired (caller is
+   * the only one running). Returns false if another process already holds it
+   * — caller should skip this run to avoid sending duplicate emails.
+   */
+  const tryAcquireLock = async (): Promise<boolean> => {
+    try {
+      const result = await db.query<{ acquired: boolean }>(
+        SQL`SELECT pg_try_advisory_lock(${NUDGE_JOB_LOCK_ID}) AS acquired`
+      )
+      return result.rows[0]?.acquired === true
+    } catch (e) {
+      logger.error(`Failed to acquire nudge-job advisory lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+      return false
+    }
+  }
+
+  const releaseLock = async (): Promise<void> => {
+    try {
+      await db.query(SQL`SELECT pg_advisory_unlock(${NUDGE_JOB_LOCK_ID})`)
+    } catch (e) {
+      logger.warn(`Failed to release nudge-job advisory lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+    }
+  }
+
   const runEvaluator = async (): Promise<void> => {
     if (!featureFlags.isNudgeEmailEnabled()) {
       logger.log('Nudge emails disabled by feature flag, skipping evaluator')
       return
     }
 
-    const whitelist = featureFlags.getNudgeEmailWhitelist()
-
-    logger.log('Running nudge evaluator...', whitelist ? { whitelist: whitelist.join(', ') } : {})
-
-    for (const sequence of [1, 2] as const) {
-      let pendingNudges
-      try {
-        pendingNudges = await onboarding.getPendingNudges(sequence)
-      } catch (e) {
-        logger.error(`Failed to fetch pending nudges for sequence ${sequence}: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
-        continue
-      }
-
-      if (whitelist) {
-        pendingNudges = pendingNudges.filter(n => whitelist.includes(n.email.toLowerCase()))
-      }
-
-      logger.log(`[SEQ:${sequence}] Found ${pendingNudges.length} pending nudges`)
-
-      for (const nudge of pendingNudges) {
-        try {
-          const messageId = await email.sendNudge({
-            to: nudge.email,
-            sequence
-          })
-
-          await onboarding.markNudgeSent(nudge.userId, sequence, messageId)
-          void notifySlack(nudge, sequence)
-        } catch (e) {
-          logger.error(
-            `[USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
-          )
-        }
-      }
+    const acquired = await tryAcquireLock()
+    if (!acquired) {
+      logger.log('Another nudge-job run holds the advisory lock — skipping this run')
+      return
     }
 
-    logger.log('Nudge evaluator finished')
+    try {
+      const whitelist = featureFlags.getNudgeEmailWhitelist()
+
+      logger.log('Running nudge evaluator...', whitelist ? { whitelist: whitelist.join(', ') } : {})
+
+      for (const sequence of [1, 2] as const) {
+        let pendingNudges
+        try {
+          pendingNudges = await onboarding.getPendingNudges(sequence)
+        } catch (e) {
+          logger.error(`Failed to fetch pending nudges for sequence ${sequence}: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+          continue
+        }
+
+        if (whitelist) {
+          pendingNudges = pendingNudges.filter(n => whitelist.includes(n.email.toLowerCase()))
+        }
+
+        logger.log(`[SEQ:${sequence}] Found ${pendingNudges.length} pending nudges`)
+
+        for (const nudge of pendingNudges) {
+          try {
+            const result = await email.sendNudge({
+              to: nudge.email,
+              sequence
+            })
+
+            if (result.messageId) {
+              analytics.fireEvent(AnalyticsEvent.NUDGE_EMAIL_SENT, {
+                user_id: nudge.userId,
+                email: nudge.email,
+                checkpoint: 2,
+                sequence,
+                template_id: result.templateId,
+                sendgrid_message_id: result.messageId,
+                sent_at: new Date().toISOString()
+              })
+              await onboarding.markNudgeSent(nudge.userId, sequence, result.messageId)
+              void notifySlack(nudge, sequence)
+            } else {
+              analytics.fireEvent(AnalyticsEvent.NUDGE_EMAIL_FAILED, {
+                user_id: nudge.userId,
+                email: nudge.email,
+                checkpoint: 2,
+                sequence,
+                template_id: result.templateId,
+                error: result.error ?? 'Unknown error',
+                failed_at: new Date().toISOString()
+              })
+            }
+          } catch (e) {
+            logger.error(
+              `[USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
+            )
+          }
+        }
+      }
+
+      logger.log('Nudge evaluator finished')
+    } finally {
+      await releaseLock()
+    }
   }
 
   const job = createJobComponent({ logs }, () => runEvaluator(), FIFTEEN_MINUTES_MS, {

--- a/src/ports/nudge-job/component.ts
+++ b/src/ports/nudge-job/component.ts
@@ -1,4 +1,4 @@
-import SQL from 'sql-template-strings'
+import { PoolClient } from 'pg'
 import { createJobComponent } from '@dcl/job-component'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { AppComponents } from '../../types'
@@ -46,25 +46,48 @@ export function createNudgeJobComponent({
   }
 
   /**
-   * Postgres advisory lock. Returns true if the lock was acquired (caller is
-   * the only one running). Returns false if another process already holds it
-   * — caller should skip this run to avoid sending duplicate emails.
+   * Acquires a Postgres session-scoped advisory lock on a DEDICATED pool
+   * client. Returns the client (caller must release it via `releaseLock`)
+   * on success, or `null` if another job already holds the lock.
+   *
+   * Why a dedicated client: `pg_try_advisory_lock` is bound to the connection
+   * that ran it. The default `db.query()` uses any connection from the pool,
+   * so an unlock issued via `db.query()` would land on a different connection
+   * and silently no-op while the lock leaks on the original. Holding one
+   * client throughout the run keeps the lock and the unlock on the same
+   * connection. The rest of the job continues to use `db.query()` normally —
+   * the dedicated client is only used to keep the lock alive.
    */
-  const tryAcquireLock = async (): Promise<boolean> => {
+  const tryAcquireLock = async (): Promise<PoolClient | null> => {
+    let client: PoolClient
     try {
-      const result = await db.query<{ acquired: boolean }>(SQL`SELECT pg_try_advisory_lock(${NUDGE_JOB_LOCK_ID}) AS acquired`)
-      return result.rows[0]?.acquired === true
+      client = await db.getPool().connect()
     } catch (e) {
+      logger.error(`Failed to acquire connection for nudge-job lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+      return null
+    }
+
+    try {
+      const result = await client.query<{ acquired: boolean }>('SELECT pg_try_advisory_lock($1) AS acquired', [NUDGE_JOB_LOCK_ID])
+      if (result.rows[0]?.acquired !== true) {
+        client.release()
+        return null
+      }
+      return client
+    } catch (e) {
+      client.release()
       logger.error(`Failed to acquire nudge-job advisory lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
-      return false
+      return null
     }
   }
 
-  const releaseLock = async (): Promise<void> => {
+  const releaseLock = async (client: PoolClient): Promise<void> => {
     try {
-      await db.query(SQL`SELECT pg_advisory_unlock(${NUDGE_JOB_LOCK_ID})`)
+      await client.query('SELECT pg_advisory_unlock($1)', [NUDGE_JOB_LOCK_ID])
     } catch (e) {
       logger.warn(`Failed to release nudge-job advisory lock: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+    } finally {
+      client.release()
     }
   }
 
@@ -74,8 +97,8 @@ export function createNudgeJobComponent({
       return
     }
 
-    const acquired = await tryAcquireLock()
-    if (!acquired) {
+    const lockClient = await tryAcquireLock()
+    if (!lockClient) {
       logger.log('Another nudge-job run holds the advisory lock — skipping this run')
       return
     }
@@ -102,16 +125,12 @@ export function createNudgeJobComponent({
 
         for (const nudge of pendingNudges) {
           try {
-            const result = await email.sendNudge({
-              to: nudge.email,
-              sequence
-            })
+            const result = await email.sendNudge({ to: nudge.email, sequence })
 
-            if (result.messageId) {
+            if (result.ok) {
               analytics.fireEvent(AnalyticsEvent.NUDGE_EMAIL_SENT, {
                 user_id: nudge.userId,
                 email: nudge.email,
-                checkpoint: 2,
                 sequence,
                 template_id: result.templateId,
                 sendgrid_message_id: result.messageId,
@@ -123,10 +142,9 @@ export function createNudgeJobComponent({
               analytics.fireEvent(AnalyticsEvent.NUDGE_EMAIL_FAILED, {
                 user_id: nudge.userId,
                 email: nudge.email,
-                checkpoint: 2,
                 sequence,
                 template_id: result.templateId,
-                error: result.error ?? 'Unknown error',
+                error: result.error,
                 failed_at: new Date().toISOString()
               })
             }
@@ -140,7 +158,7 @@ export function createNudgeJobComponent({
 
       logger.log('Nudge evaluator finished')
     } finally {
-      await releaseLock()
+      await releaseLock(lockClient)
     }
   }
 

--- a/src/ports/nudge-job/component.ts
+++ b/src/ports/nudge-job/component.ts
@@ -73,9 +73,7 @@ export function createNudgeJobComponent({
           void notifySlack(nudge, sequence)
         } catch (e) {
           logger.error(
-            `[USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${
-              isErrorWithMessage(e) ? e.message : 'Unknown error'
-            }`
+            `[USER:${nudge.userId}][SEQ:${sequence}] Failed to process nudge: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`
           )
         }
       }

--- a/src/ports/onboarding/component.ts
+++ b/src/ports/onboarding/component.ts
@@ -29,6 +29,9 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
 
       if (result.rowCount === 0) {
         logger.warn(`[CP:${checkpointId}][USER:${userIdentifier}] No existing row for completed — inserting retroactively`)
+        // ON CONFLICT preserves an existing completed_at so a duplicated
+        // 'completed' delivery (Segment retry or out-of-order webhook) doesn't
+        // shift the timestamp forward and delay nudges.
         await db.query(SQL`
           INSERT INTO onboarding_checkpoints (user_id, id_type, email, wallet, checkpoint, source, reached_at, completed_at)
           VALUES (
@@ -42,7 +45,7 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
             NOW()
           )
           ON CONFLICT (user_id, checkpoint) DO UPDATE
-            SET completed_at = NOW(),
+            SET completed_at = COALESCE(onboarding_checkpoints.completed_at, NOW()),
                 email = COALESCE(${email ?? null}, onboarding_checkpoints.email),
                 wallet = COALESCE(${wallet ?? null}, onboarding_checkpoints.wallet)
         `)
@@ -81,6 +84,23 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
         WHERE user_id = ${userIdentifier}
           AND checkpoint = 1
           AND completed_at IS NULL
+      `)
+    }
+
+    // If CP1 reached arrives AFTER CP2 was already recorded (out-of-order
+    // Segment delivery), the row would otherwise be left with completed_at=NULL
+    // even though the user clearly progressed past CP1. Close it retroactively.
+    if (checkpointId === 1) {
+      await db.query(SQL`
+        UPDATE onboarding_checkpoints
+        SET completed_at = NOW()
+        WHERE user_id = ${userIdentifier}
+          AND checkpoint = 1
+          AND completed_at IS NULL
+          AND EXISTS (
+            SELECT 1 FROM onboarding_checkpoints later
+            WHERE later.user_id = ${userIdentifier} AND later.checkpoint = 2
+          )
       `)
     }
   }

--- a/src/ports/onboarding/component.ts
+++ b/src/ports/onboarding/component.ts
@@ -3,56 +3,21 @@ import { AppComponents } from '../../types'
 import { CheckpointPayload, IOnboardingComponent, PendingNudge } from './types'
 
 // Index 0 is unused — sequence IDs start at 1.
-const SEQUENCE_HOURS = [0, 12, 24, 36]
+const SEQUENCE_HOURS = [0, 24, 72]
 
 export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db' | 'logs'>): IOnboardingComponent {
   const logger = logs.getLogger('onboarding-component')
 
-  /**
-   * When a checkpoint arrives with identifierType='wallet', try to find an
-   * earlier checkpoint row that has the same wallet and an email. If found,
-   * rewrite the identifier to the email-based user_id so all checkpoints
-   * for this user share the same user_id and the nudge system works.
-   */
-  const resolveWalletIdentity = async (walletAddress: string): Promise<{ userId: string; email: string } | null> => {
-    const result = await db.query<{ user_id: string; email: string }>(SQL`
-      SELECT user_id, email
-      FROM onboarding_checkpoints
-      WHERE wallet = ${walletAddress}
-        AND email IS NOT NULL
-      ORDER BY checkpoint ASC
-      LIMIT 1
-    `)
-    return result.rows.length > 0 ? { userId: result.rows[0].user_id, email: result.rows[0].email } : null
-  }
-
   const recordCheckpoint = async (payload: CheckpointPayload): Promise<void> => {
-    let { userIdentifier, identifierType, email, wallet } = payload
-    const { checkpointId, action, source, metadata } = payload
+    let { wallet } = payload
+    const { userIdentifier, identifierType, checkpointId, action, email, source, metadata } = payload
 
-    // Normalize wallet to lowercase
     if (wallet) {
       wallet = wallet.toLowerCase()
     }
 
-    // When identifier is a wallet, try to resolve to the email-based user_id
-    // so all checkpoints for this user share the same user_id.
-    if (identifierType === 'wallet' && !email) {
-      const resolved = await resolveWalletIdentity(userIdentifier.toLowerCase())
-      if (resolved) {
-        logger.log(`[CP:${checkpointId}][WALLET:${userIdentifier}] Resolved wallet to user_id=${resolved.userId}`)
-        wallet = wallet ?? userIdentifier.toLowerCase()
-        userIdentifier = resolved.userId
-        identifierType = 'email'
-        email = resolved.email
-      } else {
-        // No earlier checkpoint with this wallet — store with wallet as user_id
-        wallet = wallet ?? userIdentifier.toLowerCase()
-      }
-    }
-
     if (action === 'completed') {
-      await db.query(SQL`
+      const result = await db.query(SQL`
         UPDATE onboarding_checkpoints
         SET completed_at = NOW(),
             email = COALESCE(${email ?? null}, email),
@@ -61,11 +26,32 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
           AND checkpoint = ${checkpointId}
           AND completed_at IS NULL
       `)
+
+      if (result.rowCount === 0) {
+        logger.warn(`[CP:${checkpointId}][USER:${userIdentifier}] No existing row for completed — inserting retroactively`)
+        await db.query(SQL`
+          INSERT INTO onboarding_checkpoints (user_id, id_type, email, wallet, checkpoint, source, reached_at, completed_at)
+          VALUES (
+            ${userIdentifier},
+            ${identifierType},
+            ${email ?? null},
+            ${wallet ?? null},
+            ${checkpointId},
+            ${source ?? 'backfill'},
+            NOW(),
+            NOW()
+          )
+          ON CONFLICT (user_id, checkpoint) DO UPDATE
+            SET completed_at = NOW(),
+                email = COALESCE(${email ?? null}, onboarding_checkpoints.email),
+                wallet = COALESCE(${wallet ?? null}, onboarding_checkpoints.wallet)
+        `)
+      }
+
       logger.log(`[CP:${checkpointId}][USER:${userIdentifier}] Marked checkpoint as completed`)
       return
     }
 
-    // action === 'reached': upsert the checkpoint record
     await db.query(SQL`
       INSERT INTO onboarding_checkpoints (user_id, id_type, email, wallet, checkpoint, source, metadata)
       VALUES (
@@ -85,62 +71,62 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
 
     logger.log(`[CP:${checkpointId}][USER:${userIdentifier}] Recorded checkpoint reached`)
 
-    // Implicitly mark previous checkpoint as completed when reaching CP(N)
-    if (checkpointId > 1) {
+    // CP2 reached implicitly closes CP1 for the same user_id (anon→auth funnel within
+    // the same session). CP3 comes from a different source (Explorer) and may have a
+    // different user_id, so it doesn't auto-complete CP2.
+    if (checkpointId === 2) {
       await db.query(SQL`
         UPDATE onboarding_checkpoints
         SET completed_at = NOW()
         WHERE user_id = ${userIdentifier}
-          AND checkpoint = ${checkpointId - 1}
+          AND checkpoint = 1
           AND completed_at IS NULL
       `)
     }
   }
 
-  const getPendingNudges = async (sequence: 1 | 2 | 3): Promise<PendingNudge[]> => {
+  const getPendingNudges = async (sequence: 1 | 2): Promise<PendingNudge[]> => {
     const hours = SEQUENCE_HOURS[sequence]
 
-    const result = await db.query<{ user_id: string; checkpoint: number; email: string }>(SQL`
-      SELECT oc.user_id, oc.checkpoint, oc.email
-      FROM onboarding_checkpoints oc
+    const result = await db.query<{ user_id: string; email: string }>(SQL`
+      SELECT cp2.user_id, cp2.email
+      FROM onboarding_checkpoints cp2
       LEFT JOIN email_nudges en
-        ON en.user_id = oc.user_id
-        AND en.checkpoint = oc.checkpoint
-        AND en.sequence = ${sequence}
-      WHERE
-        oc.email IS NOT NULL
-        AND oc.completed_at IS NULL
-        AND oc.reached_at < NOW() - (${hours} || ' hours')::interval
+        ON en.user_id = cp2.user_id
+       AND en.checkpoint = 2
+       AND en.sequence = ${sequence}
+      WHERE cp2.checkpoint = 2
+        AND cp2.completed_at IS NOT NULL
+        AND cp2.email IS NOT NULL
+        AND cp2.completed_at < NOW() - (${hours} || ' hours')::interval
         AND en.id IS NULL
         AND NOT EXISTS (
-          SELECT 1 FROM onboarding_checkpoints later
-          WHERE later.user_id = oc.user_id
-            AND later.checkpoint > oc.checkpoint
+          SELECT 1 FROM onboarding_checkpoints cp3
+          WHERE cp3.user_id = cp2.user_id AND cp3.checkpoint = 3
         )
     `)
 
     return result.rows.map(row => ({
       userId: row.user_id,
-      checkpointId: row.checkpoint,
       email: row.email
     }))
   }
 
-  const markNudgeSent = async (userId: string, checkpointId: number, sequence: number, messageId?: string): Promise<void> => {
+  const markNudgeSent = async (userId: string, sequence: 1 | 2, messageId?: string): Promise<void> => {
     await db.query(SQL`
       INSERT INTO email_nudges (user_id, checkpoint, sequence, email, sendgrid_message_id)
       SELECT
         ${userId},
-        ${checkpointId},
+        2,
         ${sequence},
         oc.email,
         ${messageId ?? null}
       FROM onboarding_checkpoints oc
-      WHERE oc.user_id = ${userId} AND oc.checkpoint = ${checkpointId}
+      WHERE oc.user_id = ${userId} AND oc.checkpoint = 2
       ON CONFLICT (user_id, checkpoint, sequence) DO NOTHING
     `)
 
-    logger.log(`[CP:${checkpointId}][USER:${userId}][SEQ:${sequence}] Nudge marked as sent`)
+    logger.log(`[CP:2][USER:${userId}][SEQ:${sequence}] Nudge marked as sent`)
   }
 
   return {

--- a/src/ports/onboarding/types.ts
+++ b/src/ports/onboarding/types.ts
@@ -1,6 +1,6 @@
 import { IBaseComponent } from '@well-known-components/interfaces'
 
-export type IdentifierType = 'email' | 'wallet'
+export type IdentifierType = 'anon' | 'email' | 'wallet'
 export type CheckpointAction = 'reached' | 'completed'
 
 export type CheckpointPayload = {
@@ -16,12 +16,11 @@ export type CheckpointPayload = {
 
 export type PendingNudge = {
   userId: string
-  checkpointId: number
   email: string
 }
 
 export type IOnboardingComponent = IBaseComponent & {
   recordCheckpoint(payload: CheckpointPayload): Promise<void>
-  getPendingNudges(sequence: 1 | 2 | 3): Promise<PendingNudge[]>
-  markNudgeSent(userId: string, checkpointId: number, sequence: number, messageId?: string): Promise<void>
+  getPendingNudges(sequence: 1 | 2): Promise<PendingNudge[]>
+  markNudgeSent(userId: string, sequence: 1 | 2, messageId?: string): Promise<void>
 }

--- a/src/ports/onboarding/types.ts
+++ b/src/ports/onboarding/types.ts
@@ -2,11 +2,12 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 
 export type IdentifierType = 'anon' | 'email' | 'wallet'
 export type CheckpointAction = 'reached' | 'completed'
+export type CheckpointId = 1 | 2 | 3
 
 export type CheckpointPayload = {
   userIdentifier: string
   identifierType: IdentifierType
-  checkpointId: number
+  checkpointId: CheckpointId
   action: CheckpointAction
   email?: string
   wallet?: string

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -1209,6 +1209,7 @@ export async function createServerComponent({
 
         for (const seq of sequences) {
           const nudges = await onboarding.getPendingNudges(seq)
+          if (nudges.length === 0) continue
           results[`CP2 - seq ${seq}`] = {
             count: nudges.length,
             emails: nudges.map(n => n.email)
@@ -1255,8 +1256,8 @@ export async function createServerComponent({
         }
 
         try {
-          const messageId = await email.sendNudge({ to, sequence })
-          res.status(200).json({ success: true, messageId: messageId ?? null })
+          const result = await email.sendNudge({ to, sequence })
+          res.status(200).json({ success: !!result.messageId, messageId: result.messageId ?? null, error: result.error ?? null })
         } catch (e) {
           adminLogger.error(`Failed to send test email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
           res.status(500).json({ error: 'Failed to send email' })

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -1257,7 +1257,11 @@ export async function createServerComponent({
 
         try {
           const result = await email.sendNudge({ to, sequence })
-          res.status(200).json({ success: !!result.messageId, messageId: result.messageId ?? null, error: result.error ?? null })
+          if (result.ok) {
+            res.status(200).json({ success: true, messageId: result.messageId, error: null })
+          } else {
+            res.status(200).json({ success: false, messageId: null, error: result.error })
+          }
         } catch (e) {
           adminLogger.error(`Failed to send test email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
           res.status(500).json({ error: 'Failed to send email' })
@@ -1266,12 +1270,13 @@ export async function createServerComponent({
 
       // List pending nudges for a given sequence (what the cron would send next)
       app.get('/admin/onboarding/pending-nudges/:sequence', async (req: Request, res: Response) => {
-        const sequence = parseInt(req.params.sequence, 10) as 1 | 2
+        const parsed = parseInt(req.params.sequence, 10)
 
-        if (sequence !== 1 && sequence !== 2) {
+        if (parsed !== 1 && parsed !== 2) {
           sendResponse(res, 400, { error: 'sequence must be 1 or 2' })
           return
         }
+        const sequence: 1 | 2 = parsed
 
         try {
           const nudges = await onboarding.getPendingNudges(sequence)

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -1204,20 +1204,14 @@ export async function createServerComponent({
       }
 
       try {
-        const sequences = [1, 2, 3] as const
+        const sequences = [1, 2] as const
         const results: Record<string, { count: number; emails: string[] }> = {}
 
         for (const seq of sequences) {
           const nudges = await onboarding.getPendingNudges(seq)
-          // Group by checkpoint
-          const byCheckpoint = new Map<number, string[]>()
-          for (const n of nudges) {
-            const list = byCheckpoint.get(n.checkpointId) ?? []
-            list.push(n.email)
-            byCheckpoint.set(n.checkpointId, list)
-          }
-          for (const [cp, emails] of byCheckpoint) {
-            results[`CP${cp} - seq ${seq}`] = { count: emails.length, emails }
+          results[`CP2 - seq ${seq}`] = {
+            count: nudges.length,
+            emails: nudges.map(n => n.email)
           }
         }
 
@@ -1248,25 +1242,20 @@ export async function createServerComponent({
 
       // Send a test nudge email directly (bypasses DB — just calls SendGrid)
       app.post('/admin/onboarding/send-test-email', async (req: Request, res: Response) => {
-        const { to, checkpointId, sequence } = req.body
+        const { to, sequence } = req.body
 
-        if (!to || !checkpointId || !sequence) {
-          sendResponse(res, 400, { error: 'Missing required fields: to, checkpointId, sequence' })
+        if (!to || !sequence) {
+          sendResponse(res, 400, { error: 'Missing required fields: to, sequence' })
           return
         }
 
-        if (sequence < 1 || sequence > 3) {
-          sendResponse(res, 400, { error: 'sequence must be 1, 2, or 3' })
-          return
-        }
-
-        if (checkpointId < 1 || checkpointId > 7) {
-          sendResponse(res, 400, { error: 'checkpointId must be 1-7' })
+        if (sequence !== 1 && sequence !== 2) {
+          sendResponse(res, 400, { error: 'sequence must be 1 or 2' })
           return
         }
 
         try {
-          const messageId = await email.sendNudge({ to, checkpointId, sequence })
+          const messageId = await email.sendNudge({ to, sequence })
           res.status(200).json({ success: true, messageId: messageId ?? null })
         } catch (e) {
           adminLogger.error(`Failed to send test email: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
@@ -1276,10 +1265,10 @@ export async function createServerComponent({
 
       // List pending nudges for a given sequence (what the cron would send next)
       app.get('/admin/onboarding/pending-nudges/:sequence', async (req: Request, res: Response) => {
-        const sequence = parseInt(req.params.sequence, 10) as 1 | 2 | 3
+        const sequence = parseInt(req.params.sequence, 10) as 1 | 2
 
-        if (![1, 2, 3].includes(sequence)) {
-          sendResponse(res, 400, { error: 'sequence must be 1, 2, or 3' })
+        if (sequence !== 1 && sequence !== 2) {
+          sendResponse(res, 400, { error: 'sequence must be 1 or 2' })
           return
         }
 

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -91,7 +91,7 @@ export type IdentityIdValidationResponse = {
 }
 
 export type CheckpointRequest = {
-  checkpointId: number
+  checkpointId: 1 | 2 | 3
   userIdentifier: string
   identifierType: 'anon' | 'email' | 'wallet'
   action: 'reached' | 'completed'

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -93,7 +93,7 @@ export type IdentityIdValidationResponse = {
 export type CheckpointRequest = {
   checkpointId: number
   userIdentifier: string
-  identifierType: 'email' | 'wallet'
+  identifierType: 'anon' | 'email' | 'wallet'
   action: 'reached' | 'completed'
   email?: string
   wallet?: string

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -140,7 +140,7 @@ const checkpointRequestSchema = {
     checkpointId: {
       type: 'integer',
       minimum: 1,
-      maximum: 7
+      maximum: 3
     },
     userIdentifier: {
       type: 'string',
@@ -149,7 +149,7 @@ const checkpointRequestSchema = {
     },
     identifierType: {
       type: 'string',
-      enum: ['email', 'wallet']
+      enum: ['anon', 'email', 'wallet']
     },
     action: {
       type: 'string',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { IAnalyticsComponent } from '@dcl/analytics-component'
 import type { ICacheStorageComponent } from '@dcl/core-commons'
 import type { ISlackComponent } from '@dcl/slack-component'
 import type { IFeatureFlagsAdapter } from './adapters/feature-flags'
@@ -8,6 +9,7 @@ import type { INudgeJobComponent } from './ports/nudge-job/types'
 import type { IOnboardingComponent } from './ports/onboarding/types'
 import type { IServerComponent } from './ports/server/types'
 import type { IStorageComponent } from './ports/storage/types'
+import type { AnalyticsEventPayload } from './types/analytics'
 import type { IFeaturesComponent } from '@well-known-components/features-component'
 import type {
   IConfigComponent,
@@ -23,6 +25,7 @@ export type GlobalContext = {
 
 // components used in every environment.
 export type BaseComponents = {
+  analytics: IAnalyticsComponent<AnalyticsEventPayload>
   config: IConfigComponent
   fetch: IFetchComponent
   features: IFeaturesComponent

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -3,20 +3,23 @@ export enum AnalyticsEvent {
   NUDGE_EMAIL_FAILED = 'NUDGE_EMAIL_FAILED'
 }
 
+/**
+ * `checkpoint` is intentionally absent from these payloads — the only
+ * checkpoint that triggers nudges is CP2, so emitting it would carry no
+ * signal. If a second nudge target is added in the future, reintroduce it.
+ */
 export type AnalyticsEventPayload = {
   [AnalyticsEvent.NUDGE_EMAIL_SENT]: {
     user_id: string
     email: string
-    checkpoint: number
     sequence: 1 | 2
     template_id: string
-    sendgrid_message_id?: string
+    sendgrid_message_id: string
     sent_at: string
   }
   [AnalyticsEvent.NUDGE_EMAIL_FAILED]: {
     user_id: string
     email: string
-    checkpoint: number
     sequence: 1 | 2
     template_id: string
     error: string

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,25 @@
+export enum AnalyticsEvent {
+  NUDGE_EMAIL_SENT = 'NUDGE_EMAIL_SENT',
+  NUDGE_EMAIL_FAILED = 'NUDGE_EMAIL_FAILED'
+}
+
+export type AnalyticsEventPayload = {
+  [AnalyticsEvent.NUDGE_EMAIL_SENT]: {
+    user_id: string
+    email: string
+    checkpoint: number
+    sequence: 1 | 2
+    template_id: string
+    sendgrid_message_id?: string
+    sent_at: string
+  }
+  [AnalyticsEvent.NUDGE_EMAIL_FAILED]: {
+    user_id: string
+    email: string
+    checkpoint: number
+    sequence: 1 | 2
+    template_id: string
+    error: string
+    failed_at: string
+  }
+}

--- a/test/components.ts
+++ b/test/components.ts
@@ -122,7 +122,12 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
   } as unknown as TestComponents['featureFlags']
   const fetch = { fetch: jest.fn() } as unknown as TestComponents['fetch']
   const features = { getIsFeatureEnabled: jest.fn(), getFeatureVariant: jest.fn() } as unknown as TestComponents['features']
-  const nudgeJob = createNudgeJobComponent({ onboarding, email, slack, logs: createMockLogs(), config, featureFlags })
+  const analytics = {
+    fireEvent: jest.fn(),
+    sendEvents: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn().mockResolvedValue(undefined)
+  } as unknown as TestComponents['analytics']
+  const nudgeJob = createNudgeJobComponent({ onboarding, email, slack, logs: createMockLogs(), config, featureFlags, analytics, db })
   const server = await createServerComponent({
     config,
     logs,
@@ -137,6 +142,7 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
   })
 
   return {
+    analytics,
     config,
     fetch,
     features,

--- a/test/integration/onboarding-endpoint.spec.ts
+++ b/test/integration/onboarding-endpoint.spec.ts
@@ -221,32 +221,27 @@ test('when calling GET /onboarding/pending-nudges with valid auth and pending nu
   beforeEach(async () => {
     port = await args.components.config.requireString('HTTP_SERVER_PORT')
     mockDb = args.components.db as unknown as jest.Mocked<Pick<IPgComponent, 'query'>>
-    // Return different results per sequence call
+    // getPendingNudges only queries CP2 rows now and returns { user_id, email }.
     let callCount = 0
     mockDb.query = jest.fn().mockImplementation(() => {
       callCount++
       if (callCount === 1) {
-        // seq 1: two CP2 nudges, one CP3 nudge
+        // seq 1: two CP2 stuck users
         return {
           rows: [
-            { user_id: 'a@test.com', checkpoint: 2, email: 'a@test.com' },
-            { user_id: 'b@test.com', checkpoint: 2, email: 'b@test.com' },
-            { user_id: 'c@test.com', checkpoint: 3, email: 'c@test.com' }
+            { user_id: 'anon-a', email: 'a@test.com' },
+            { user_id: 'anon-b', email: 'b@test.com' }
           ],
-          rowCount: 3,
+          rowCount: 2,
           notices: []
         }
       }
-      if (callCount === 2) {
-        // seq 2: one CP2 nudge
-        return { rows: [{ user_id: 'a@test.com', checkpoint: 2, email: 'a@test.com' }], rowCount: 1, notices: [] }
-      }
-      // seq 3: empty
-      return { rows: [], rowCount: 0, notices: [] }
+      // seq 2: one CP2 stuck user
+      return { rows: [{ user_id: 'anon-a', email: 'a@test.com' }], rowCount: 1, notices: [] }
     })
   })
 
-  it('should return grouped pending nudges by CP and sequence', async () => {
+  it('should return grouped pending nudges by sequence', async () => {
     const response = await fetch(`http://localhost:${port}/onboarding/pending-nudges`, {
       method: 'GET',
       headers: { origin: 'https://test-auth.org', ...AUTH_HEADER }
@@ -255,10 +250,9 @@ test('when calling GET /onboarding/pending-nudges with valid auth and pending nu
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body['CP2 - seq 1']).toEqual({ count: 2, emails: ['a@test.com', 'b@test.com'] })
-    expect(body['CP3 - seq 1']).toEqual({ count: 1, emails: ['c@test.com'] })
     expect(body['CP2 - seq 2']).toEqual({ count: 1, emails: ['a@test.com'] })
-    // seq 3 has no nudges, so no keys for it
-    expect(Object.keys(body).filter(k => k.includes('seq 3'))).toHaveLength(0)
+    // CP3 is no longer a nudge target; only CP2 is exposed
+    expect(Object.keys(body).filter(k => !k.startsWith('CP2'))).toHaveLength(0)
   })
 })
 

--- a/test/unit/email-component.spec.ts
+++ b/test/unit/email-component.spec.ts
@@ -68,9 +68,9 @@ describe('when sending a nudge for sequence 1', () => {
     expect(msg.dynamicTemplateData.buttonUrl).toBe('https://decentraland.org/download')
   })
 
-  it('should return the SendGrid message id', async () => {
-    const messageId = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
-    expect(messageId).toBe('sg-msg-id-123')
+  it('should return the templateId and SendGrid message id', async () => {
+    const result = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
+    expect(result).toEqual({ templateId: 'd-template-id', messageId: 'sg-msg-id-123' })
   })
 
   it('should send to the correct recipient', async () => {
@@ -104,8 +104,10 @@ describe('when SendGrid returns an error', () => {
     await expect(email.sendNudge({ to: 'user@test.com', sequence: 1 })).resolves.not.toThrow()
   })
 
-  it('should return undefined', async () => {
+  it('should return templateId with error and no messageId', async () => {
     const result = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
-    expect(result).toBeUndefined()
+    expect(result.templateId).toBe('d-template-id')
+    expect(result.messageId).toBeUndefined()
+    expect(result.error).toContain('SendGrid API error')
   })
 })

--- a/test/unit/email-component.spec.ts
+++ b/test/unit/email-component.spec.ts
@@ -38,35 +38,17 @@ beforeEach(async () => {
   email = await createEmailComponent({ config: createMockConfig(), logs: createMockLogs() })
 })
 
-describe('when sending a nudge for checkpoint 3, sequence 1', () => {
+describe('when sending a nudge for sequence 1', () => {
   it('should call sgMail.send with the configured template', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
+    await email.sendNudge({ to: 'user@test.com', sequence: 1 })
 
     expect(sgMail.send).toHaveBeenCalledTimes(1)
     const [msg] = sgMail.send.mock.calls[0]
     expect(msg.templateId).toBe('d-template-id')
   })
 
-  it('should include checkpoint 3 context in template data', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.dynamicTemplateData).toMatchObject({
-      checkpointId: 3,
-      subject: 'Finish Choosing Your Name',
-      heading: expect.stringContaining('choosing your name')
-    })
-  })
-
-  it('should include buttonUrl pointing to auth login', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.dynamicTemplateData.buttonUrl).toBe('https://decentraland.org/auth/login')
-  })
-
-  it('should include subject, preheader, heading, body, buttonText, and tagline', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
+  it('should include subject, preheader, heading, body, buttonText, buttonUrl and tagline', async () => {
+    await email.sendNudge({ to: 'user@test.com', sequence: 1 })
 
     const [msg] = sgMail.send.mock.calls[0]
     const data = msg.dynamicTemplateData
@@ -75,66 +57,41 @@ describe('when sending a nudge for checkpoint 3, sequence 1', () => {
     expect(data.heading).toBeDefined()
     expect(data.body).toBeDefined()
     expect(data.buttonText).toBeDefined()
+    expect(data.buttonUrl).toBeDefined()
     expect(data.tagline).toBeDefined()
   })
 
+  it('should point CTA to the download/launcher page', async () => {
+    await email.sendNudge({ to: 'user@test.com', sequence: 1 })
+
+    const [msg] = sgMail.send.mock.calls[0]
+    expect(msg.dynamicTemplateData.buttonUrl).toBe('https://decentraland.org/download')
+  })
+
   it('should return the SendGrid message id', async () => {
-    const messageId = await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
+    const messageId = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
     expect(messageId).toBe('sg-msg-id-123')
   })
 
   it('should send to the correct recipient', async () => {
-    await email.sendNudge({ to: 'specific@test.com', checkpointId: 3, sequence: 1 })
+    await email.sendNudge({ to: 'specific@test.com', sequence: 1 })
 
     const [msg] = sgMail.send.mock.calls[0]
     expect(msg.to).toBe('specific@test.com')
   })
 })
 
-describe('when sending a nudge for different sequences', () => {
-  it('should use different subjects for different sequences', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
+describe('when sending nudges for different sequences', () => {
+  it('should use different subjects for sequence 1 vs sequence 2', async () => {
+    await email.sendNudge({ to: 'user@test.com', sequence: 1 })
     const [msg1] = sgMail.send.mock.calls[0]
 
     sgMail.send.mockClear()
 
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 3 })
-    const [msg3] = sgMail.send.mock.calls[0]
+    await email.sendNudge({ to: 'user@test.com', sequence: 2 })
+    const [msg2] = sgMail.send.mock.calls[0]
 
-    expect(msg1.dynamicTemplateData.subject).not.toBe(msg3.dynamicTemplateData.subject)
-  })
-})
-
-describe('when sending a nudge for checkpoint 5, sequence 2 (download page)', () => {
-  it('should include a CTA url pointing to download', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 5, sequence: 2 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.dynamicTemplateData.buttonUrl).toBe('https://decentraland.org/download')
-  })
-
-  it('should use the correct buttonText', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 5, sequence: 2 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.dynamicTemplateData.buttonText).toBe('Download Decentraland')
-  })
-})
-
-describe('when sending a nudge for an unmapped checkpoint (CP7 fallback)', () => {
-  it('should use the same template ID', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 7, sequence: 3 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.templateId).toBe('d-template-id')
-  })
-
-  it('should use fallback content with generic subject', async () => {
-    await email.sendNudge({ to: 'user@test.com', checkpointId: 7, sequence: 3 })
-
-    const [msg] = sgMail.send.mock.calls[0]
-    expect(msg.dynamicTemplateData.subject).toBe('Continue your Decentraland setup')
-    expect(msg.dynamicTemplateData.buttonUrl).toBe('decentraland://')
+    expect(msg1.dynamicTemplateData.subject).not.toBe(msg2.dynamicTemplateData.subject)
   })
 })
 
@@ -144,11 +101,11 @@ describe('when SendGrid returns an error', () => {
   })
 
   it('should not throw', async () => {
-    await expect(email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })).resolves.not.toThrow()
+    await expect(email.sendNudge({ to: 'user@test.com', sequence: 1 })).resolves.not.toThrow()
   })
 
   it('should return undefined', async () => {
-    const result = await email.sendNudge({ to: 'user@test.com', checkpointId: 3, sequence: 1 })
+    const result = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
     expect(result).toBeUndefined()
   })
 })

--- a/test/unit/email-component.spec.ts
+++ b/test/unit/email-component.spec.ts
@@ -70,7 +70,7 @@ describe('when sending a nudge for sequence 1', () => {
 
   it('should return the templateId and SendGrid message id', async () => {
     const result = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
-    expect(result).toEqual({ templateId: 'd-template-id', messageId: 'sg-msg-id-123' })
+    expect(result).toEqual({ ok: true, templateId: 'd-template-id', messageId: 'sg-msg-id-123' })
   })
 
   it('should send to the correct recipient', async () => {
@@ -104,10 +104,12 @@ describe('when SendGrid returns an error', () => {
     await expect(email.sendNudge({ to: 'user@test.com', sequence: 1 })).resolves.not.toThrow()
   })
 
-  it('should return templateId with error and no messageId', async () => {
+  it('should return ok=false with templateId and error', async () => {
     const result = await email.sendNudge({ to: 'user@test.com', sequence: 1 })
-    expect(result.templateId).toBe('d-template-id')
-    expect(result.messageId).toBeUndefined()
-    expect(result.error).toContain('SendGrid API error')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.templateId).toBe('d-template-id')
+      expect(result.error).toContain('SendGrid API error')
+    }
   })
 })

--- a/test/unit/nudge-job.spec.ts
+++ b/test/unit/nudge-job.spec.ts
@@ -65,16 +65,24 @@ function createMockFeatureFlags(enabled = true, whitelist?: string[]): IFeatureF
 }
 
 function createMockDb(lockAcquired = true) {
+  // Mock PoolClient: handles the pg_try_advisory_lock / pg_advisory_unlock
+  // dance and ignores other queries (the job uses db.query() for them).
+  const mockClient = {
+    query: jest.fn().mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) {
+        return { rows: [{ acquired: lockAcquired }], rowCount: 1 }
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        return { rows: [{ pg_advisory_unlock: true }], rowCount: 1 }
+      }
+      return { rows: [], rowCount: 0 }
+    }),
+    release: jest.fn()
+  }
   return {
-    query: jest.fn().mockImplementation(async (q: unknown) => {
-      const text = typeof q === 'object' && q !== null && 'text' in q ? String((q as { text: string }).text) : String(q)
-      if (text.includes('pg_try_advisory_lock')) {
-        return { rows: [{ acquired: lockAcquired }], rowCount: 1, notices: [] }
-      }
-      if (text.includes('pg_advisory_unlock')) {
-        return { rows: [{ pg_advisory_unlock: true }], rowCount: 1, notices: [] }
-      }
-      return { rows: [], rowCount: 0, notices: [] }
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0, notices: [] }),
+    getPool: jest.fn().mockReturnValue({
+      connect: jest.fn().mockResolvedValue(mockClient)
     })
   }
 }
@@ -109,7 +117,7 @@ beforeEach(() => {
   mockDb = createMockDb()
 
   mockOnboarding.markNudgeSent.mockResolvedValue(undefined)
-  mockEmail.sendNudge.mockResolvedValue({ templateId: TEMPLATE_ID, messageId: 'sg-msg-id-123' })
+  mockEmail.sendNudge.mockResolvedValue({ ok: true, templateId: TEMPLATE_ID, messageId: 'sg-msg-id-123' })
 
   nudgeJob = buildJob()
 })
@@ -143,7 +151,6 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
       expect.objectContaining({
         user_id: 'anon-uuid-1',
         email: 'stuck@test.com',
-        checkpoint: 2,
         sequence: 1,
         template_id: TEMPLATE_ID,
         sendgrid_message_id: 'sg-msg-id-123',
@@ -173,7 +180,7 @@ describe('when running the nudge evaluator with pending nudges for both sequence
 
 describe('when sendNudge returns an error result (no messageId)', () => {
   beforeEach(() => {
-    mockEmail.sendNudge.mockResolvedValue({ templateId: TEMPLATE_ID, error: 'SendGrid API error' })
+    mockEmail.sendNudge.mockResolvedValue({ ok: false, templateId: TEMPLATE_ID, error: 'SendGrid API error' })
     mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }]).mockResolvedValue([])
   })
 
@@ -190,7 +197,6 @@ describe('when sendNudge returns an error result (no messageId)', () => {
       expect.objectContaining({
         user_id: 'anon-1',
         email: 'user@test.com',
-        checkpoint: 2,
         sequence: 1,
         template_id: TEMPLATE_ID,
         error: 'SendGrid API error',
@@ -204,7 +210,7 @@ describe('when sendNudge throws', () => {
   beforeEach(() => {
     mockEmail.sendNudge
       .mockRejectedValueOnce(new Error('network error'))
-      .mockResolvedValueOnce({ templateId: TEMPLATE_ID, messageId: 'sg-msg-id-ok' })
+      .mockResolvedValueOnce({ ok: true, templateId: TEMPLATE_ID, messageId: 'sg-msg-id-ok' })
 
     mockOnboarding.getPendingNudges
       .mockResolvedValueOnce([

--- a/test/unit/nudge-job.spec.ts
+++ b/test/unit/nudge-job.spec.ts
@@ -1,10 +1,17 @@
 import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IAnalyticsComponent } from '@dcl/analytics-component'
 import { ISlackComponent } from '@dcl/slack-component'
 import { IFeatureFlagsAdapter } from '../../src/adapters/feature-flags'
+import { IPgComponent } from '../../src/ports/db/types'
 import { IEmailComponent } from '../../src/ports/email/types'
 import { createNudgeJobComponent } from '../../src/ports/nudge-job/component'
 import { INudgeJobComponent } from '../../src/ports/nudge-job/types'
 import { IOnboardingComponent, PendingNudge } from '../../src/ports/onboarding/types'
+import { AnalyticsEvent, AnalyticsEventPayload } from '../../src/types/analytics'
+
+type AppComponentsDb = IPgComponent
+
+const TEMPLATE_ID = 'd-template-id'
 
 function createMockLogs(): ILoggerComponent {
   const logger = { log: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() }
@@ -30,6 +37,14 @@ function createMockSlack(): jest.Mocked<Pick<ISlackComponent, 'sendMessage'>> {
   }
 }
 
+function createMockAnalytics() {
+  return {
+    fireEvent: jest.fn(),
+    sendEvents: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn().mockResolvedValue(undefined)
+  }
+}
+
 function createMockConfig(overrides: Record<string, string> = {}): IConfigComponent {
   return {
     getString: jest.fn().mockImplementation(async (key: string) => overrides[key] ?? undefined),
@@ -49,29 +64,54 @@ function createMockFeatureFlags(enabled = true, whitelist?: string[]): IFeatureF
   } as unknown as IFeatureFlagsAdapter
 }
 
+function createMockDb(lockAcquired = true) {
+  return {
+    query: jest.fn().mockImplementation(async (q: unknown) => {
+      const text = typeof q === 'object' && q !== null && 'text' in q ? String((q as { text: string }).text) : String(q)
+      if (text.includes('pg_try_advisory_lock')) {
+        return { rows: [{ acquired: lockAcquired }], rowCount: 1, notices: [] }
+      }
+      if (text.includes('pg_advisory_unlock')) {
+        return { rows: [{ pg_advisory_unlock: true }], rowCount: 1, notices: [] }
+      }
+      return { rows: [], rowCount: 0, notices: [] }
+    })
+  }
+}
+
 let nudgeJob: INudgeJobComponent
 let mockOnboarding: ReturnType<typeof createMockOnboarding>
 let mockEmail: ReturnType<typeof createMockEmail>
 let mockSlack: ReturnType<typeof createMockSlack>
+let mockAnalytics: ReturnType<typeof createMockAnalytics>
 let mockFeatureFlags: IFeatureFlagsAdapter
+let mockDb: ReturnType<typeof createMockDb>
+
+function buildJob(configOverrides: Record<string, string> = { SLACK_NUDGE_CHANNEL: 'test-channel' }) {
+  return createNudgeJobComponent({
+    onboarding: mockOnboarding as unknown as IOnboardingComponent,
+    email: mockEmail as unknown as IEmailComponent,
+    slack: mockSlack as unknown as ISlackComponent,
+    logs: createMockLogs(),
+    config: createMockConfig(configOverrides),
+    featureFlags: mockFeatureFlags,
+    analytics: mockAnalytics as unknown as IAnalyticsComponent<AnalyticsEventPayload>,
+    db: mockDb as unknown as AppComponentsDb
+  })
+}
 
 beforeEach(() => {
   mockOnboarding = createMockOnboarding()
   mockEmail = createMockEmail()
   mockSlack = createMockSlack()
+  mockAnalytics = createMockAnalytics()
   mockFeatureFlags = createMockFeatureFlags()
+  mockDb = createMockDb()
 
   mockOnboarding.markNudgeSent.mockResolvedValue(undefined)
-  mockEmail.sendNudge.mockResolvedValue('sg-msg-id-123')
+  mockEmail.sendNudge.mockResolvedValue({ templateId: TEMPLATE_ID, messageId: 'sg-msg-id-123' })
 
-  nudgeJob = createNudgeJobComponent({
-    onboarding: mockOnboarding as unknown as IOnboardingComponent,
-    email: mockEmail as unknown as IEmailComponent,
-    slack: mockSlack as unknown as ISlackComponent,
-    logs: createMockLogs(),
-    config: createMockConfig({ SLACK_NUDGE_CHANNEL: 'test-channel' }),
-    featureFlags: mockFeatureFlags
-  })
+  nudgeJob = buildJob()
 })
 
 describe('when running the nudge evaluator with pending nudges for sequence 1', () => {
@@ -80,18 +120,13 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
   beforeEach(() => {
     pendingNudge = { userId: 'anon-uuid-1', email: 'stuck@test.com' }
 
-    mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([pendingNudge]) // sequence 1
-      .mockResolvedValue([]) // sequence 2
+    mockOnboarding.getPendingNudges.mockResolvedValueOnce([pendingNudge]).mockResolvedValue([])
   })
 
   it('should send the nudge email', async () => {
     await nudgeJob.runEvaluator()
 
-    expect(mockEmail.sendNudge).toHaveBeenCalledWith({
-      to: 'stuck@test.com',
-      sequence: 1
-    })
+    expect(mockEmail.sendNudge).toHaveBeenCalledWith({ to: 'stuck@test.com', sequence: 1 })
   })
 
   it('should mark the nudge as sent with the returned message id', async () => {
@@ -99,13 +134,30 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
 
     expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('anon-uuid-1', 1, 'sg-msg-id-123')
   })
+
+  it('should fire the NUDGE_EMAIL_SENT analytics event', async () => {
+    await nudgeJob.runEvaluator()
+
+    expect(mockAnalytics.fireEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.NUDGE_EMAIL_SENT,
+      expect.objectContaining({
+        user_id: 'anon-uuid-1',
+        email: 'stuck@test.com',
+        checkpoint: 2,
+        sequence: 1,
+        template_id: TEMPLATE_ID,
+        sendgrid_message_id: 'sg-msg-id-123',
+        sent_at: expect.any(String)
+      })
+    )
+  })
 })
 
 describe('when running the nudge evaluator with pending nudges for both sequences', () => {
   beforeEach(() => {
     mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user1@test.com' }]) // seq 1
-      .mockResolvedValueOnce([{ userId: 'anon-2', email: 'user2@test.com' }]) // seq 2
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user1@test.com' }])
+      .mockResolvedValueOnce([{ userId: 'anon-2', email: 'user2@test.com' }])
   })
 
   it('should process both sequences', async () => {
@@ -115,32 +167,50 @@ describe('when running the nudge evaluator with pending nudges for both sequence
     expect(mockOnboarding.getPendingNudges).toHaveBeenCalledWith(1)
     expect(mockOnboarding.getPendingNudges).toHaveBeenCalledWith(2)
     expect(mockEmail.sendNudge).toHaveBeenCalledTimes(2)
+    expect(mockAnalytics.fireEvent).toHaveBeenCalledTimes(2)
   })
 })
 
-describe('when email sending returns undefined (failure)', () => {
+describe('when sendNudge returns an error result (no messageId)', () => {
   beforeEach(() => {
-    mockEmail.sendNudge.mockResolvedValue(undefined)
+    mockEmail.sendNudge.mockResolvedValue({ templateId: TEMPLATE_ID, error: 'SendGrid API error' })
     mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }]).mockResolvedValue([])
   })
 
-  it('should still call markNudgeSent with undefined messageId', async () => {
+  it('should NOT call markNudgeSent', async () => {
+    await nudgeJob.runEvaluator()
+    expect(mockOnboarding.markNudgeSent).not.toHaveBeenCalled()
+  })
+
+  it('should fire the NUDGE_EMAIL_FAILED analytics event with the error', async () => {
     await nudgeJob.runEvaluator()
 
-    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('anon-1', 1, undefined)
+    expect(mockAnalytics.fireEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.NUDGE_EMAIL_FAILED,
+      expect.objectContaining({
+        user_id: 'anon-1',
+        email: 'user@test.com',
+        checkpoint: 2,
+        sequence: 1,
+        template_id: TEMPLATE_ID,
+        error: 'SendGrid API error',
+        failed_at: expect.any(String)
+      })
+    )
   })
 })
 
-describe('when email sending throws', () => {
-  let secondNudge: PendingNudge
-
+describe('when sendNudge throws', () => {
   beforeEach(() => {
-    secondNudge = { userId: 'anon-2', email: 'user2@test.com' }
-
-    mockEmail.sendNudge.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce('sg-msg-id-ok')
+    mockEmail.sendNudge
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ templateId: TEMPLATE_ID, messageId: 'sg-msg-id-ok' })
 
     mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user1@test.com' }, secondNudge])
+      .mockResolvedValueOnce([
+        { userId: 'anon-1', email: 'user1@test.com' },
+        { userId: 'anon-2', email: 'user2@test.com' }
+      ])
       .mockResolvedValue([])
   })
 
@@ -170,13 +240,18 @@ describe('when there are no pending nudges', () => {
     await nudgeJob.runEvaluator()
     expect(mockOnboarding.markNudgeSent).not.toHaveBeenCalled()
   })
+
+  it('should not fire any analytics event', async () => {
+    await nudgeJob.runEvaluator()
+    expect(mockAnalytics.fireEvent).not.toHaveBeenCalled()
+  })
 })
 
 describe('when getPendingNudges throws for one sequence', () => {
   beforeEach(() => {
     mockOnboarding.getPendingNudges
-      .mockRejectedValueOnce(new Error('DB connection error')) // seq 1 fails
-      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }]) // seq 2 ok
+      .mockRejectedValueOnce(new Error('DB connection error'))
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }])
   })
 
   it('should continue to process the other sequence', async () => {
@@ -217,15 +292,7 @@ describe('slack notifications', () => {
   describe('when SLACK_NUDGE_CHANNEL is not configured', () => {
     beforeEach(() => {
       mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }]).mockResolvedValue([])
-
-      nudgeJob = createNudgeJobComponent({
-        onboarding: mockOnboarding as unknown as IOnboardingComponent,
-        email: mockEmail as unknown as IEmailComponent,
-        slack: mockSlack as unknown as ISlackComponent,
-        logs: createMockLogs(),
-        config: createMockConfig(),
-        featureFlags: mockFeatureFlags
-      })
+      nudgeJob = buildJob({})
     })
 
     it('should not send a Slack message', async () => {
@@ -254,19 +321,27 @@ describe('slack notifications', () => {
   })
 })
 
+describe('when another nudge-job run holds the advisory lock', () => {
+  beforeEach(() => {
+    mockDb = createMockDb(false) // pg_try_advisory_lock returns false
+    mockOnboarding.getPendingNudges.mockResolvedValue([{ userId: 'anon-1', email: 'user@test.com' }])
+    nudgeJob = buildJob()
+  })
+
+  it('should skip the run without querying or sending emails', async () => {
+    await nudgeJob.runEvaluator()
+
+    expect(mockOnboarding.getPendingNudges).not.toHaveBeenCalled()
+    expect(mockEmail.sendNudge).not.toHaveBeenCalled()
+    expect(mockAnalytics.fireEvent).not.toHaveBeenCalled()
+  })
+})
+
 describe('when nudge emails feature flag is disabled', () => {
   beforeEach(() => {
     mockFeatureFlags = createMockFeatureFlags(false)
     mockOnboarding.getPendingNudges.mockResolvedValue([{ userId: 'anon-1', email: 'user@test.com' }])
-
-    nudgeJob = createNudgeJobComponent({
-      onboarding: mockOnboarding as unknown as IOnboardingComponent,
-      email: mockEmail as unknown as IEmailComponent,
-      slack: mockSlack as unknown as ISlackComponent,
-      logs: createMockLogs(),
-      config: createMockConfig({ SLACK_NUDGE_CHANNEL: 'test-channel' }),
-      featureFlags: mockFeatureFlags
-    })
+    nudgeJob = buildJob()
   })
 
   it('should skip the evaluator entirely', async () => {
@@ -274,6 +349,7 @@ describe('when nudge emails feature flag is disabled', () => {
 
     expect(mockOnboarding.getPendingNudges).not.toHaveBeenCalled()
     expect(mockEmail.sendNudge).not.toHaveBeenCalled()
+    expect(mockAnalytics.fireEvent).not.toHaveBeenCalled()
   })
 })
 
@@ -288,15 +364,7 @@ describe('when nudge emails feature flag has a whitelist', () => {
         { userId: 'anon-3', email: 'VIP@test.com' }
       ])
       .mockResolvedValue([])
-
-    nudgeJob = createNudgeJobComponent({
-      onboarding: mockOnboarding as unknown as IOnboardingComponent,
-      email: mockEmail as unknown as IEmailComponent,
-      slack: mockSlack as unknown as ISlackComponent,
-      logs: createMockLogs(),
-      config: createMockConfig({ SLACK_NUDGE_CHANNEL: 'test-channel' }),
-      featureFlags: mockFeatureFlags
-    })
+    nudgeJob = buildJob()
   })
 
   it('should only send nudges to whitelisted emails', async () => {

--- a/test/unit/nudge-job.spec.ts
+++ b/test/unit/nudge-job.spec.ts
@@ -78,11 +78,11 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
   let pendingNudge: PendingNudge
 
   beforeEach(() => {
-    pendingNudge = { userId: 'stuck@test.com', checkpointId: 3, email: 'stuck@test.com' }
+    pendingNudge = { userId: 'anon-uuid-1', email: 'stuck@test.com' }
 
     mockOnboarding.getPendingNudges
       .mockResolvedValueOnce([pendingNudge]) // sequence 1
-      .mockResolvedValue([]) // sequences 2 and 3
+      .mockResolvedValue([]) // sequence 2
   })
 
   it('should send the nudge email', async () => {
@@ -90,7 +90,6 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
 
     expect(mockEmail.sendNudge).toHaveBeenCalledWith({
       to: 'stuck@test.com',
-      checkpointId: 3,
       sequence: 1
     })
   })
@@ -98,26 +97,24 @@ describe('when running the nudge evaluator with pending nudges for sequence 1', 
   it('should mark the nudge as sent with the returned message id', async () => {
     await nudgeJob.runEvaluator()
 
-    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('stuck@test.com', 3, 1, 'sg-msg-id-123')
+    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('anon-uuid-1', 1, 'sg-msg-id-123')
   })
 })
 
-describe('when running the nudge evaluator with pending nudges for multiple sequences', () => {
+describe('when running the nudge evaluator with pending nudges for both sequences', () => {
   beforeEach(() => {
     mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'user1@test.com', checkpointId: 2, email: 'user1@test.com' }]) // seq 1
-      .mockResolvedValueOnce([{ userId: 'user2@test.com', checkpointId: 3, email: 'user2@test.com' }]) // seq 2
-      .mockResolvedValueOnce([{ userId: 'user3@test.com', checkpointId: 1, email: 'user3@test.com' }]) // seq 3
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user1@test.com' }]) // seq 1
+      .mockResolvedValueOnce([{ userId: 'anon-2', email: 'user2@test.com' }]) // seq 2
   })
 
-  it('should process all three sequences', async () => {
+  it('should process both sequences', async () => {
     await nudgeJob.runEvaluator()
 
-    expect(mockOnboarding.getPendingNudges).toHaveBeenCalledTimes(3)
+    expect(mockOnboarding.getPendingNudges).toHaveBeenCalledTimes(2)
     expect(mockOnboarding.getPendingNudges).toHaveBeenCalledWith(1)
     expect(mockOnboarding.getPendingNudges).toHaveBeenCalledWith(2)
-    expect(mockOnboarding.getPendingNudges).toHaveBeenCalledWith(3)
-    expect(mockEmail.sendNudge).toHaveBeenCalledTimes(3)
+    expect(mockEmail.sendNudge).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -125,14 +122,14 @@ describe('when email sending returns undefined (failure)', () => {
   beforeEach(() => {
     mockEmail.sendNudge.mockResolvedValue(undefined)
     mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'user@test.com', checkpointId: 3, email: 'user@test.com' }])
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }])
       .mockResolvedValue([])
   })
 
   it('should still call markNudgeSent with undefined messageId', async () => {
     await nudgeJob.runEvaluator()
 
-    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('user@test.com', 3, 1, undefined)
+    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('anon-1', 1, undefined)
   })
 })
 
@@ -140,12 +137,12 @@ describe('when email sending throws', () => {
   let secondNudge: PendingNudge
 
   beforeEach(() => {
-    secondNudge = { userId: 'user2@test.com', checkpointId: 2, email: 'user2@test.com' }
+    secondNudge = { userId: 'anon-2', email: 'user2@test.com' }
 
     mockEmail.sendNudge.mockRejectedValueOnce(new Error('network error')).mockResolvedValueOnce('sg-msg-id-ok')
 
     mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'user1@test.com', checkpointId: 3, email: 'user1@test.com' }, secondNudge])
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user1@test.com' }, secondNudge])
       .mockResolvedValue([])
   })
 
@@ -153,7 +150,7 @@ describe('when email sending throws', () => {
     await nudgeJob.runEvaluator()
 
     expect(mockEmail.sendNudge).toHaveBeenCalledTimes(2)
-    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('user2@test.com', 2, 1, 'sg-msg-id-ok')
+    expect(mockOnboarding.markNudgeSent).toHaveBeenCalledWith('anon-2', 1, 'sg-msg-id-ok')
   })
 
   it('should not throw', async () => {
@@ -181,11 +178,10 @@ describe('when getPendingNudges throws for one sequence', () => {
   beforeEach(() => {
     mockOnboarding.getPendingNudges
       .mockRejectedValueOnce(new Error('DB connection error')) // seq 1 fails
-      .mockResolvedValueOnce([{ userId: 'user@test.com', checkpointId: 3, email: 'user@test.com' }]) // seq 2 ok
-      .mockResolvedValueOnce([]) // seq 3 ok
+      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }]) // seq 2 ok
   })
 
-  it('should continue to process other sequences', async () => {
+  it('should continue to process the other sequence', async () => {
     await nudgeJob.runEvaluator()
 
     expect(mockEmail.sendNudge).toHaveBeenCalledTimes(1)
@@ -201,7 +197,7 @@ describe('slack notifications', () => {
   describe('when SLACK_NUDGE_CHANNEL is configured', () => {
     beforeEach(() => {
       mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'stuck@test.com', checkpointId: 3, email: 'stuck@test.com' }])
+        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
         .mockResolvedValue([])
     })
 
@@ -213,7 +209,7 @@ describe('slack notifications', () => {
 
       expect(mockSlack.sendMessage).toHaveBeenCalledWith({
         channel: 'test-channel',
-        text: expect.stringContaining('CP3')
+        text: expect.stringContaining('stuck@test.com')
       })
       expect(mockSlack.sendMessage).toHaveBeenCalledWith({
         channel: 'test-channel',
@@ -225,7 +221,7 @@ describe('slack notifications', () => {
   describe('when SLACK_NUDGE_CHANNEL is not configured', () => {
     beforeEach(() => {
       mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'stuck@test.com', checkpointId: 3, email: 'stuck@test.com' }])
+        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
         .mockResolvedValue([])
 
       nudgeJob = createNudgeJobComponent({
@@ -251,7 +247,7 @@ describe('slack notifications', () => {
     beforeEach(() => {
       mockSlack.sendMessage.mockRejectedValue(new Error('Slack API error'))
       mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'stuck@test.com', checkpointId: 3, email: 'stuck@test.com' }])
+        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
         .mockResolvedValue([])
     })
 
@@ -269,7 +265,7 @@ describe('slack notifications', () => {
 describe('when nudge emails feature flag is disabled', () => {
   beforeEach(() => {
     mockFeatureFlags = createMockFeatureFlags(false)
-    mockOnboarding.getPendingNudges.mockResolvedValue([{ userId: 'user@test.com', checkpointId: 3, email: 'user@test.com' }])
+    mockOnboarding.getPendingNudges.mockResolvedValue([{ userId: 'anon-1', email: 'user@test.com' }])
 
     nudgeJob = createNudgeJobComponent({
       onboarding: mockOnboarding as unknown as IOnboardingComponent,
@@ -295,9 +291,9 @@ describe('when nudge emails feature flag has a whitelist', () => {
 
     mockOnboarding.getPendingNudges
       .mockResolvedValueOnce([
-        { userId: 'allowed@test.com', checkpointId: 2, email: 'allowed@test.com' },
-        { userId: 'random@test.com', checkpointId: 3, email: 'random@test.com' },
-        { userId: 'vip@test.com', checkpointId: 1, email: 'VIP@test.com' }
+        { userId: 'anon-1', email: 'allowed@test.com' },
+        { userId: 'anon-2', email: 'random@test.com' },
+        { userId: 'anon-3', email: 'VIP@test.com' }
       ])
       .mockResolvedValue([])
 

--- a/test/unit/nudge-job.spec.ts
+++ b/test/unit/nudge-job.spec.ts
@@ -121,9 +121,7 @@ describe('when running the nudge evaluator with pending nudges for both sequence
 describe('when email sending returns undefined (failure)', () => {
   beforeEach(() => {
     mockEmail.sendNudge.mockResolvedValue(undefined)
-    mockOnboarding.getPendingNudges
-      .mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }])
-      .mockResolvedValue([])
+    mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'user@test.com' }]).mockResolvedValue([])
   })
 
   it('should still call markNudgeSent with undefined messageId', async () => {
@@ -196,9 +194,7 @@ describe('when getPendingNudges throws for one sequence', () => {
 describe('slack notifications', () => {
   describe('when SLACK_NUDGE_CHANNEL is configured', () => {
     beforeEach(() => {
-      mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
-        .mockResolvedValue([])
+      mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }]).mockResolvedValue([])
     })
 
     it('should send a Slack message after nudge is sent', async () => {
@@ -220,9 +216,7 @@ describe('slack notifications', () => {
 
   describe('when SLACK_NUDGE_CHANNEL is not configured', () => {
     beforeEach(() => {
-      mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
-        .mockResolvedValue([])
+      mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }]).mockResolvedValue([])
 
       nudgeJob = createNudgeJobComponent({
         onboarding: mockOnboarding as unknown as IOnboardingComponent,
@@ -246,9 +240,7 @@ describe('slack notifications', () => {
   describe('when Slack sendMessage throws', () => {
     beforeEach(() => {
       mockSlack.sendMessage.mockRejectedValue(new Error('Slack API error'))
-      mockOnboarding.getPendingNudges
-        .mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }])
-        .mockResolvedValue([])
+      mockOnboarding.getPendingNudges.mockResolvedValueOnce([{ userId: 'anon-1', email: 'stuck@test.com' }]).mockResolvedValue([])
     })
 
     it('should not affect nudge processing', async () => {

--- a/test/unit/onboarding-component.spec.ts
+++ b/test/unit/onboarding-component.spec.ts
@@ -29,36 +29,51 @@ beforeEach(() => {
 })
 
 describe('when recording a checkpoint with action reached', () => {
-  describe('and the user has an email', () => {
+  describe('and identifierType is anon (CP1)', () => {
     beforeEach(() => {
       mockDb.query.mockResolvedValue(emptyResult)
     })
 
-    it('should upsert the checkpoint with the provided email', async () => {
+    it('should upsert the checkpoint with id_type=anon', async () => {
       await onboarding.recordCheckpoint({
-        userIdentifier: 'user@test.com',
-        identifierType: 'email',
-        checkpointId: 2,
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 1,
         action: 'reached',
-        email: 'user@test.com',
-        source: 'auth'
+        source: 'landing'
       })
 
-      // No wallet resolution needed, so: upsert + update previous
-      expect(mockDb.query.mock.calls).toHaveLength(2)
+      expect(mockDb.query.mock.calls).toHaveLength(1)
       const [firstCall] = mockDb.query.mock.calls
       const queryText = firstCall[0].text ?? firstCall[0]
       expect(queryText).toContain('INSERT INTO onboarding_checkpoints')
       expect(queryText).toContain('ON CONFLICT')
+      expect(firstCall[0].values).toContain('anon')
     })
 
-    it('should implicitly mark the previous checkpoint as completed', async () => {
+    it('should not attempt to update a previous checkpoint when CP=1', async () => {
       await onboarding.recordCheckpoint({
-        userIdentifier: 'user@test.com',
-        identifierType: 'email',
-        checkpointId: 3,
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 1,
+        action: 'reached'
+      })
+
+      expect(mockDb.query.mock.calls).toHaveLength(1)
+    })
+  })
+
+  describe('and checkpointId is 2 (auth)', () => {
+    beforeEach(() => {
+      mockDb.query.mockResolvedValue(emptyResult)
+    })
+
+    it('should upsert and implicitly close CP1 for the same user_id', async () => {
+      await onboarding.recordCheckpoint({
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 2,
         action: 'reached',
-        email: 'user@test.com',
         source: 'auth'
       })
 
@@ -66,316 +81,170 @@ describe('when recording a checkpoint with action reached', () => {
       const [, secondCall] = mockDb.query.mock.calls
       const queryText = secondCall[0].text ?? secondCall[0]
       expect(queryText).toContain('UPDATE onboarding_checkpoints')
-      expect(queryText).toContain('completed_at')
+      expect(queryText).toContain('completed_at = NOW()')
+      expect(queryText).toContain('checkpoint = 1')
     })
   })
 
-  describe('and the user does not have an email (wallet-only)', () => {
-    beforeEach(() => {
-      // resolveWalletIdentity does a SELECT to look up email for the wallet — returns empty
-      mockDb.query.mockResolvedValue(emptyResult)
-    })
-
-    it('should look up email by wallet and fall back to wallet as user_id', async () => {
-      await onboarding.recordCheckpoint({
-        userIdentifier: '0xabc123',
-        identifierType: 'wallet',
-        checkpointId: 3,
-        action: 'reached'
-      })
-
-      // First call is the wallet resolution query, second is the upsert
-      const upsertCall = mockDb.query.mock.calls[1]
-      // email value should be null in the upsert query values
-      expect(upsertCall[0].values).toContain(null)
-    })
-  })
-
-  describe('and checkpointId is 1 (first checkpoint)', () => {
+  describe('and checkpointId is 3 (in-world)', () => {
     beforeEach(() => {
       mockDb.query.mockResolvedValue(emptyResult)
     })
 
-    it('should not attempt to update a previous checkpoint', async () => {
+    it('should upsert without auto-completing previous checkpoints', async () => {
       await onboarding.recordCheckpoint({
-        userIdentifier: 'user@test.com',
-        identifierType: 'email',
-        checkpointId: 1,
-        action: 'reached'
-      })
-
-      expect(mockDb.query.mock.calls).toHaveLength(1) // only the upsert, no previous update
-    })
-  })
-
-  describe('and the user provides a wallet field', () => {
-    beforeEach(() => {
-      mockDb.query.mockResolvedValue(emptyResult)
-    })
-
-    it('should include wallet in the INSERT query', async () => {
-      await onboarding.recordCheckpoint({
-        userIdentifier: 'user@test.com',
-        identifierType: 'email',
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
         checkpointId: 3,
         action: 'reached',
-        email: 'user@test.com',
-        wallet: '0xABC123',
-        source: 'auth'
+        wallet: '0xABC',
+        source: 'explorer'
       })
 
+      expect(mockDb.query.mock.calls).toHaveLength(1)
       const [firstCall] = mockDb.query.mock.calls
-      const queryText = firstCall[0].text ?? firstCall[0]
-      expect(queryText).toContain('wallet')
-      // wallet should be lowercased
-      expect(firstCall[0].values).toContain('0xabc123')
-    })
-  })
-})
-
-describe('wallet-to-email resolution', () => {
-  describe('when identifierType is wallet and no email is provided', () => {
-    describe('and an earlier checkpoint with that wallet exists', () => {
-      beforeEach(() => {
-        // First call: resolveWalletIdentity query — returns a match
-        mockDb.query
-          .mockResolvedValueOnce({
-            rows: [{ user_id: 'user@test.com', email: 'user@test.com' }],
-            rowCount: 1,
-            notices: []
-          })
-          // Second call: INSERT (upsert)
-          .mockResolvedValueOnce(emptyResult)
-          // Third call: UPDATE previous checkpoint
-          .mockResolvedValueOnce(emptyResult)
-      })
-
-      it('should resolve wallet to the email-based user_id', async () => {
-        await onboarding.recordCheckpoint({
-          userIdentifier: '0xabc123',
-          identifierType: 'wallet',
-          checkpointId: 7,
-          action: 'reached',
-          source: 'explorer'
-        })
-
-        // Should have 3 queries: resolve + upsert + update previous
-        expect(mockDb.query.mock.calls).toHaveLength(3)
-
-        // First query should be the wallet lookup
-        const [resolveCall] = mockDb.query.mock.calls
-        const resolveText = resolveCall[0].text ?? resolveCall[0]
-        expect(resolveText).toContain('SELECT user_id, email')
-        expect(resolveText).toContain('WHERE wallet')
-
-        // Second query (upsert) should use the resolved email as user_id
-        const [, upsertCall] = mockDb.query.mock.calls
-        expect(upsertCall[0].values).toContain('user@test.com') // resolved user_id
-      })
-
-      it('should use the resolved email for the checkpoint row', async () => {
-        await onboarding.recordCheckpoint({
-          userIdentifier: '0xabc123',
-          identifierType: 'wallet',
-          checkpointId: 7,
-          action: 'reached',
-          source: 'explorer'
-        })
-
-        const [, upsertCall] = mockDb.query.mock.calls
-        // The resolved email should appear in the values
-        expect(upsertCall[0].values).toContain('user@test.com')
-      })
-    })
-
-    describe('and no earlier checkpoint with that wallet exists', () => {
-      beforeEach(() => {
-        // First call: resolveWalletIdentity query — no match
-        mockDb.query
-          .mockResolvedValueOnce(emptyResult)
-          // Second call: INSERT (upsert)
-          .mockResolvedValueOnce(emptyResult)
-          // Third call: UPDATE previous checkpoint
-          .mockResolvedValueOnce(emptyResult)
-      })
-
-      it('should use the wallet as-is for user_id', async () => {
-        await onboarding.recordCheckpoint({
-          userIdentifier: '0xabc123',
-          identifierType: 'wallet',
-          checkpointId: 7,
-          action: 'reached',
-          source: 'explorer'
-        })
-
-        // Should have 3 queries: resolve + upsert + update previous
-        expect(mockDb.query.mock.calls).toHaveLength(3)
-
-        // Upsert should use the original wallet as user_id
-        const [, upsertCall] = mockDb.query.mock.calls
-        expect(upsertCall[0].values).toContain('0xabc123')
-      })
+      expect(firstCall[0].values).toContain('0xabc') // wallet lowercased
     })
   })
 
-  describe('when identifierType is wallet but email IS provided', () => {
+  describe('and a wallet is provided', () => {
     beforeEach(() => {
       mockDb.query.mockResolvedValue(emptyResult)
     })
 
-    it('should not attempt wallet resolution', async () => {
+    it('should lowercase the wallet before insert', async () => {
       await onboarding.recordCheckpoint({
-        userIdentifier: '0xabc123',
-        identifierType: 'wallet',
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
         checkpointId: 2,
         action: 'reached',
-        email: 'already-known@test.com'
+        wallet: '0xABCDEF'
       })
 
-      // Should have 2 queries: upsert + update previous (no resolve query)
-      expect(mockDb.query.mock.calls).toHaveLength(2)
       const [firstCall] = mockDb.query.mock.calls
-      const queryText = firstCall[0].text ?? firstCall[0]
-      expect(queryText).toContain('INSERT INTO onboarding_checkpoints')
-    })
-  })
-
-  describe('when identifierType is email', () => {
-    beforeEach(() => {
-      mockDb.query.mockResolvedValue(emptyResult)
-    })
-
-    it('should not attempt wallet resolution', async () => {
-      await onboarding.recordCheckpoint({
-        userIdentifier: 'user@test.com',
-        identifierType: 'email',
-        checkpointId: 3,
-        action: 'reached',
-        email: 'user@test.com'
-      })
-
-      // Should have 2 queries: upsert + update previous (no resolve query)
-      expect(mockDb.query.mock.calls).toHaveLength(2)
-      const [firstCall] = mockDb.query.mock.calls
-      const queryText = firstCall[0].text ?? firstCall[0]
-      expect(queryText).toContain('INSERT INTO onboarding_checkpoints')
+      expect(firstCall[0].values).toContain('0xabcdef')
     })
   })
 })
 
 describe('when recording a checkpoint with action completed', () => {
-  beforeEach(() => {
-    mockDb.query.mockResolvedValue({ rows: [], rowCount: 1, notices: [] })
-  })
-
-  it('should update completed_at on the matching checkpoint row', async () => {
-    await onboarding.recordCheckpoint({
-      userIdentifier: 'user@test.com',
-      identifierType: 'email',
-      checkpointId: 3,
-      action: 'completed'
+  describe('and the row exists', () => {
+    beforeEach(() => {
+      mockDb.query.mockResolvedValue({ rows: [], rowCount: 1, notices: [] })
     })
 
-    expect(mockDb.query.mock.calls).toHaveLength(1)
-    const [firstCall] = mockDb.query.mock.calls
-    const queryText = firstCall[0].text ?? firstCall[0]
-    expect(queryText).toContain('UPDATE onboarding_checkpoints')
-    expect(queryText).toContain('completed_at = NOW()')
-  })
+    it('should update completed_at on the matching row', async () => {
+      await onboarding.recordCheckpoint({
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 2,
+        action: 'completed',
+        email: 'user@test.com',
+        wallet: '0xabc'
+      })
 
-  it('should not insert a new row', async () => {
-    await onboarding.recordCheckpoint({
-      userIdentifier: 'user@test.com',
-      identifierType: 'email',
-      checkpointId: 3,
-      action: 'completed'
+      expect(mockDb.query.mock.calls).toHaveLength(1)
+      const [firstCall] = mockDb.query.mock.calls
+      const queryText = firstCall[0].text ?? firstCall[0]
+      expect(queryText).toContain('UPDATE onboarding_checkpoints')
+      expect(queryText).toContain('completed_at = NOW()')
     })
 
-    const [firstCall] = mockDb.query.mock.calls
-    const queryText = firstCall[0].text ?? firstCall[0]
-    expect(queryText).not.toContain('INSERT INTO')
+    it('should enrich email and wallet with COALESCE', async () => {
+      await onboarding.recordCheckpoint({
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 2,
+        action: 'completed',
+        email: 'enriched@test.com'
+      })
+
+      const [firstCall] = mockDb.query.mock.calls
+      expect(firstCall[0].values).toContain('enriched@test.com')
+    })
   })
 
-  it('should update email if provided during completion', async () => {
-    await onboarding.recordCheckpoint({
-      userIdentifier: '0xabc',
-      identifierType: 'wallet',
-      checkpointId: 3,
-      action: 'completed',
-      email: 'provided@test.com'
+  describe('and the row does not exist (no prior reached)', () => {
+    beforeEach(() => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [], rowCount: 0, notices: [] }) // UPDATE returns 0 rows
+        .mockResolvedValueOnce(emptyResult) // INSERT retroactivo
     })
 
-    const [firstCall] = mockDb.query.mock.calls
-    expect(firstCall[0].values).toContain('provided@test.com')
+    it('should insert the row retroactively', async () => {
+      await onboarding.recordCheckpoint({
+        userIdentifier: 'anon-uuid-1',
+        identifierType: 'anon',
+        checkpointId: 2,
+        action: 'completed',
+        email: 'user@test.com'
+      })
+
+      expect(mockDb.query.mock.calls).toHaveLength(2)
+      const [, secondCall] = mockDb.query.mock.calls
+      const queryText = secondCall[0].text ?? secondCall[0]
+      expect(queryText).toContain('INSERT INTO onboarding_checkpoints')
+      expect(queryText).toContain('ON CONFLICT')
+    })
   })
 })
 
 describe('when getting pending nudges', () => {
-  describe('for sequence 1 (12 hours)', () => {
+  describe('for sequence 1 (24 hours)', () => {
     beforeEach(() => {
       mockDb.query.mockResolvedValue({
         rows: [
-          { user_id: 'stuck@test.com', checkpoint: 3, email: 'stuck@test.com' },
-          { user_id: '0xabc', checkpoint: 2, email: 'wallet-user@test.com' }
+          { user_id: 'anon-1', email: 'stuck1@test.com' },
+          { user_id: 'anon-2', email: 'stuck2@test.com' }
         ],
         rowCount: 2,
         notices: []
       })
     })
 
-    it('should query with 12 hour interval', async () => {
-      await onboarding.getPendingNudges(1)
-
-      const [firstCall] = mockDb.query.mock.calls
-      expect(firstCall[0].values).toContain(12)
-    })
-
-    it('should return mapped pending nudge objects', async () => {
-      const result = await onboarding.getPendingNudges(1)
-
-      expect(result).toHaveLength(2)
-      expect(result[0]).toEqual({ userId: 'stuck@test.com', checkpointId: 3, email: 'stuck@test.com' })
-      expect(result[1]).toEqual({ userId: '0xabc', checkpointId: 2, email: 'wallet-user@test.com' })
-    })
-
-    it('should exclude users who have progressed to a later checkpoint (NOT EXISTS guard)', async () => {
-      await onboarding.getPendingNudges(1)
-
-      const [firstCall] = mockDb.query.mock.calls
-      const queryText = firstCall[0].text ?? firstCall[0]
-      expect(queryText).toContain('NOT EXISTS')
-      expect(queryText).toContain('later.checkpoint > oc.checkpoint')
-    })
-  })
-
-  describe('for sequence 2 (24 hours)', () => {
-    beforeEach(() => {
-      mockDb.query.mockResolvedValue(emptyResult)
-    })
-
     it('should query with 24 hour interval', async () => {
-      await onboarding.getPendingNudges(2)
+      await onboarding.getPendingNudges(1)
 
       const [firstCall] = mockDb.query.mock.calls
       expect(firstCall[0].values).toContain(24)
     })
 
-    it('should return empty array when no pending nudges', async () => {
-      const result = await onboarding.getPendingNudges(2)
-      expect(result).toEqual([])
+    it('should query CP2 completed without CP3', async () => {
+      await onboarding.getPendingNudges(1)
+
+      const [firstCall] = mockDb.query.mock.calls
+      const queryText = firstCall[0].text ?? firstCall[0]
+      expect(queryText).toContain('cp2.checkpoint = 2')
+      expect(queryText).toContain('cp2.completed_at IS NOT NULL')
+      expect(queryText).toContain('cp2.email IS NOT NULL')
+      expect(queryText).toContain('NOT EXISTS')
+      expect(queryText).toContain('cp3.checkpoint = 3')
+    })
+
+    it('should return mapped pending nudge objects (userId + email)', async () => {
+      const result = await onboarding.getPendingNudges(1)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ userId: 'anon-1', email: 'stuck1@test.com' })
+      expect(result[1]).toEqual({ userId: 'anon-2', email: 'stuck2@test.com' })
     })
   })
 
-  describe('for sequence 3 (36 hours)', () => {
+  describe('for sequence 2 (72 hours)', () => {
     beforeEach(() => {
       mockDb.query.mockResolvedValue(emptyResult)
     })
 
-    it('should query with 36 hour interval', async () => {
-      await onboarding.getPendingNudges(3)
+    it('should query with 72 hour interval', async () => {
+      await onboarding.getPendingNudges(2)
 
       const [firstCall] = mockDb.query.mock.calls
-      expect(firstCall[0].values).toContain(36)
+      expect(firstCall[0].values).toContain(72)
+    })
+
+    it('should return empty array when no pending nudges', async () => {
+      const result = await onboarding.getPendingNudges(2)
+      expect(result).toEqual([])
     })
   })
 })
@@ -385,8 +254,8 @@ describe('when marking a nudge as sent', () => {
     mockDb.query.mockResolvedValue({ rows: [], rowCount: 1, notices: [] })
   })
 
-  it('should insert into email_nudges table', async () => {
-    await onboarding.markNudgeSent('user@test.com', 3, 1, 'sg-msg-id-123')
+  it('should insert into email_nudges with checkpoint=2', async () => {
+    await onboarding.markNudgeSent('anon-1', 1, 'sg-msg-id-123')
 
     expect(mockDb.query.mock.calls).toHaveLength(1)
     const [firstCall] = mockDb.query.mock.calls
@@ -395,21 +264,21 @@ describe('when marking a nudge as sent', () => {
   })
 
   it('should include the sendgrid message id', async () => {
-    await onboarding.markNudgeSent('user@test.com', 3, 1, 'sg-msg-id-456')
+    await onboarding.markNudgeSent('anon-1', 1, 'sg-msg-id-456')
 
     const [firstCall] = mockDb.query.mock.calls
     expect(firstCall[0].values).toContain('sg-msg-id-456')
   })
 
   it('should work without a message id', async () => {
-    await expect(onboarding.markNudgeSent('user@test.com', 3, 1)).resolves.not.toThrow()
+    await expect(onboarding.markNudgeSent('anon-1', 1)).resolves.not.toThrow()
 
     const [firstCall] = mockDb.query.mock.calls
     expect(firstCall[0].values).toContain(null)
   })
 
   it('should use ON CONFLICT DO NOTHING to prevent duplicates', async () => {
-    await onboarding.markNudgeSent('user@test.com', 3, 1, 'sg-msg-id')
+    await onboarding.markNudgeSent('anon-1', 1, 'sg-msg-id')
 
     const [firstCall] = mockDb.query.mock.calls
     const queryText = firstCall[0].text ?? firstCall[0]

--- a/test/unit/onboarding-component.spec.ts
+++ b/test/unit/onboarding-component.spec.ts
@@ -43,7 +43,8 @@ describe('when recording a checkpoint with action reached', () => {
         source: 'landing'
       })
 
-      expect(mockDb.query.mock.calls).toHaveLength(1)
+      // 1 INSERT + 1 retroactive close-if-CP2-exists guard
+      expect(mockDb.query.mock.calls).toHaveLength(2)
       const [firstCall] = mockDb.query.mock.calls
       const queryText = firstCall[0].text ?? firstCall[0]
       expect(queryText).toContain('INSERT INTO onboarding_checkpoints')
@@ -51,7 +52,7 @@ describe('when recording a checkpoint with action reached', () => {
       expect(firstCall[0].values).toContain('anon')
     })
 
-    it('should not attempt to update a previous checkpoint when CP=1', async () => {
+    it('should issue a guard query that closes CP1 if CP2 already exists', async () => {
       await onboarding.recordCheckpoint({
         userIdentifier: 'anon-uuid-1',
         identifierType: 'anon',
@@ -59,7 +60,11 @@ describe('when recording a checkpoint with action reached', () => {
         action: 'reached'
       })
 
-      expect(mockDb.query.mock.calls).toHaveLength(1)
+      const [, secondCall] = mockDb.query.mock.calls
+      const queryText = secondCall[0].text ?? secondCall[0]
+      expect(queryText).toContain('UPDATE onboarding_checkpoints')
+      expect(queryText).toContain('checkpoint = 1')
+      expect(queryText).toContain('later.checkpoint = 2')
     })
   })
 

--- a/test/unit/onboarding-validators.spec.ts
+++ b/test/unit/onboarding-validators.spec.ts
@@ -21,12 +21,22 @@ describe('when validating a valid checkpoint request', () => {
     expect(result).toMatchObject({ action: 'completed', identifierType: 'email' })
   })
 
-  it('should accept all checkpoint ids from 1 to 7', () => {
-    for (let id = 1; id <= 7; id++) {
+  it('should accept all checkpoint ids from 1 to 3', () => {
+    for (let id = 1; id <= 3; id++) {
       expect(() =>
-        validateCheckpointRequest({ checkpointId: id, userIdentifier: 'x', identifierType: 'wallet', action: 'reached' })
+        validateCheckpointRequest({ checkpointId: id, userIdentifier: 'x', identifierType: 'anon', action: 'reached' })
       ).not.toThrow()
     }
+  })
+
+  it('should accept identifierType = "anon"', () => {
+    const result = validateCheckpointRequest({
+      checkpointId: 1,
+      userIdentifier: '11111111-1111-4111-8111-111111111111',
+      identifierType: 'anon',
+      action: 'reached'
+    })
+    expect(result.identifierType).toBe('anon')
   })
 
   it('should accept an optional email field with valid format', () => {
@@ -68,8 +78,8 @@ describe('when validating an invalid checkpoint request', () => {
     expect(() => validateCheckpointRequest({ checkpointId: 0, userIdentifier: 'x', identifierType: 'wallet', action: 'reached' })).toThrow()
   })
 
-  it('should reject checkpointId = 8', () => {
-    expect(() => validateCheckpointRequest({ checkpointId: 8, userIdentifier: 'x', identifierType: 'wallet', action: 'reached' })).toThrow()
+  it('should reject checkpointId = 4 (out of new range)', () => {
+    expect(() => validateCheckpointRequest({ checkpointId: 4, userIdentifier: 'x', identifierType: 'wallet', action: 'reached' })).toThrow()
   })
 
   it('should reject unknown identifierType', () => {


### PR DESCRIPTION
# Onboarding redesign — Download First (auth-server)

## Summary

Replaces the 7-checkpoint / 21-template onboarding tracking with **3 checkpoints (CP1–CP3) and 2 nudge templates**. Adds the new `id_type='anon'` so all rows of a user share the same `user_id` (the Segment `anon_user_id`) end-to-end, with `email`/`wallet` filled in via `COALESCE` as auth completes.

Full rationale, flow diagram, and template specs in `ONBOARDING_REDESIGN.md`. Step-by-step manual testing in `TESTING_GUIDE.md`.

## Why

The old funnel was modeled around a "web first" flow (login on the web → setup → download → launcher) that no longer exists. The new flow is **download first**: landing → launcher → Explorer → auth → back to Explorer. With the launcher already propagating `campaign_anon_user_id`, and landing + auth living on `decentraland.org` (shared Segment cookie), a single `anon_user_id` ties all checkpoints together — no more wallet→email reconciliation, no more 21 email variants. Nudges now target the only meaningful drop-off: **users who completed auth but never entered the world**.

## Changes

| File | Why |
|---|---|
| `src/migrations/1777795200000_onboarding_redesign_download_first.ts` | New constraints (`checkpoint 1-3`, `id_type ∈ {anon,email,wallet}`, `sequence ∈ {1,2}`), legacy data cleanup, partial index for the new nudge query. |
| `src/ports/onboarding/types.ts` | `IdentifierType` adds `'anon'`; `getPendingNudges` is now `1 \| 2`; `markNudgeSent` no longer takes `checkpointId` (always CP2). |
| `src/ports/onboarding/component.ts` | `SEQUENCE_HOURS = [0, 24, 72]`. New nudge query: CP2 completed with email and no CP3. CP2 reached implicitly closes CP1 for the same `user_id`. Removed wallet→email reconciliation (no longer needed — `user_id` is always the anon id). |
| `src/ports/email/types.ts` | `SendNudgeParams` drops `checkpointId`; `sequence` narrowed to `1 \| 2`. |
| `src/ports/email/component.ts` | `NUDGE_CONTENT` reduced from 21 → **2** entries (seq 1 at 24h, seq 2 at 72h). Single CTA → `/download`. |
| `src/ports/nudge-job/component.ts` | Loop sequences `[1, 2]`. Slack message text updated to reflect "authenticated but not in-world". |
| `src/ports/server/validations.ts` | `checkpointId` 1–3, `identifierType` accepts `'anon'`. |
| `src/ports/server/types.ts` | `CheckpointRequest.identifierType` widened. |
| `src/ports/server/component.ts` | `/onboarding/pending-nudges` and admin endpoints aligned with the new model (only sequences 1 and 2). |
| `test/unit/onboarding-component.spec.ts` | Rewritten: anon-keyed flow, new nudge query, CP2-only `markNudgeSent`. |
| `test/unit/email-component.spec.ts` | Rewritten: 2 templates, `sendNudge({to, sequence})` shape. |
| `test/unit/nudge-job.spec.ts` | Updated mocks to the new `PendingNudge` (`{userId, email}`) and `markNudgeSent` signature. |
| `ONBOARDING_TRACKING.md` | Doc rewritten for the new model (3 CPs, anon-id funnel, 24h/72h cadence, updated SQL queries). |
| `ONBOARDING_REDESIGN.md` | New doc — full flow diagram, checkpoint specs, nudge logic, **template specs for marketing**, per-repo summary. |
| `TESTING_GUIDE.md` | New doc — 9 manual test scenarios end-to-end with curl + SQL. |

## Test plan

- [ ] `pnpm migrate` runs cleanly against a copy of staging DB; constraints + index verified.
- [ ] `pnpm test` — 41 unit tests pass across `onboarding`, `email`, `nudge-job`.
- [ ] Run all 9 scenarios in `TESTING_GUIDE.md` in staging with SendGrid sandbox.
- [ ] At least one real internal email completes the full happy path + a real seq-1 nudge.
- [ ] Feature flag `nudge-emails` stays OFF in prod until staging is green.

## Related PRs

- `events-notifier` — `feat/onboarding-redesign-download-first` (CP3 mapping from `logged_in`).
- `auth` — `fix/quick-setup-celebration` (CP2 reached/completed, removed CP3/CP4).
- `landing-site` — `feat/onboarding-redesign-download-first` (CP1 with `anon_user_id`).
