### PR TITLE
feat: add Magic account self-deletion endpoint (DELETE /accounts)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -27,9 +27,9 @@ REQUEST_EXPIRATION_IN_SECONDS=300
 MAGIC_SECRET_KEY=DUMMY_MAGIC_SECRET_KEY
 # Base URL of Magic's admin API (the deletion endpoint lives here).
 MAGIC_API_URL=https://api.magic.link
-# Optional Magic app client id. When set, DID token validation also enforces the
-# `aud` claim. Leave empty to skip the audience check.
-# MAGIC_CLIENT_ID=
+# Magic app client id (the DID token `aud`). Required — token validation enforces it.
+# Defaults to the Magic test-app client id (local dev uses the test app); public, not a secret.
+MAGIC_CLIENT_ID=GAdEkc7JBSB-8Awe1WYezUmzC-zM4OZWAXQw3BSnGNM=
 # Max age (seconds) of a DID token accepted for deletion — enforces a freshly
 # minted, deliberate confirmation and bounds the replay window.
 MAGIC_DID_TOKEN_MAX_AGE_SECONDS=120

--- a/.env.default
+++ b/.env.default
@@ -21,6 +21,22 @@ DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS=600
 # Expiration time in second for all other requests
 REQUEST_EXPIRATION_IN_SECONDS=300
 
+# ── Magic account deletion ────────────────────────────────────────────────
+# Magic application SECRET key (X-Magic-Secret-Key). Sensitive — provide via the
+# deploy secret store, never commit a real value. Dummy default so dev can boot.
+MAGIC_SECRET_KEY=DUMMY_MAGIC_SECRET_KEY
+# Base URL of Magic's admin API (the deletion endpoint lives here).
+MAGIC_API_URL=https://api.magic.link
+# Optional Magic app client id. When set, DID token validation also enforces the
+# `aud` claim. Leave empty to skip the audience check.
+# MAGIC_CLIENT_ID=
+# Max age (seconds) of a DID token accepted for deletion — enforces a freshly
+# minted, deliberate confirmation and bounds the replay window.
+MAGIC_DID_TOKEN_MAX_AGE_SECONDS=120
+# Semicolon-separated allowlist of browser Origins permitted to call the
+# deletion endpoint (defense-in-depth on top of CORS). Empty = check skipped.
+ACCOUNT_DELETION_ALLOWED_ORIGINS=https://decentraland.org;https://account.decentraland.org;https://play.decentraland.org
+
 # PostgreSQL connection for onboarding tracking
 # Use PG_COMPONENT_PSQL_CONNECTION_STRING OR individual vars below
 # PG_COMPONENT_PSQL_CONNECTION_STRING=

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dcl/redis-component": "^3.0.1",
         "@dcl/schemas": "^9.6.0",
         "@dcl/slack-component": "^1.0.6",
+        "@magic-sdk/admin": "^2.8.2",
         "@sendgrid/mail": "^8.1.6",
         "@sentry/node": "10.39.0",
         "@well-known-components/env-config-provider": "^1.2.0",
@@ -1891,6 +1892,32 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@magic-sdk/admin": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/admin/-/admin-2.8.2.tgz",
+      "integrity": "sha512-7SUkdLJDLprnGfJAu1je6m+VtWe8itptVMdGCd1wMg6mPZEl2h7i0kIznoCzQSQFsPHzsb7D5ldwkTDtZTPd6A==",
+      "license": "MIT",
+      "dependencies": {
+        "ethereum-cryptography": "^3.2.0",
+        "ethers": "^6.15.0",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -6043,6 +6070,86 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.2.tgz",
       "integrity": "sha512-OQcImRiHUKCyMtI7GtGD+nfcGToPvkuYp+REnYOcaWwCXghv6RNESowX0t7OVnHcln3qyAJiH/mCaoq1S6KD5w=="
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-3.2.0.tgz",
+      "integrity": "sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.0",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+      "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/ethers": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@dcl/redis-component": "^3.0.1",
     "@dcl/schemas": "^9.6.0",
     "@dcl/slack-component": "^1.0.6",
+    "@magic-sdk/admin": "^2.8.2",
     "@sendgrid/mail": "^8.1.6",
     "@sentry/node": "10.39.0",
     "@well-known-components/env-config-provider": "^1.2.0",

--- a/src/adapters/magic/component.ts
+++ b/src/adapters/magic/component.ts
@@ -1,0 +1,88 @@
+import { Magic, SDKError, ErrorCode } from '@magic-sdk/admin'
+import { isErrorWithMessage } from '../../logic/error-handling'
+import { AppComponents } from '../../types'
+import { MagicAuthError, MagicDeletionError, MagicRateLimitError, MagicTokenExpiredError, MagicTokenInvalidError } from './errors'
+import { DidTokenValidationResult, IMagicAdapter, MagicDeletionResult } from './types'
+
+// Magic's GDPR deletion endpoint (see docs.magic.link .../data/deletion-request).
+// Note: this lives on api.magic.link, which differs from the admin SDK's default
+// host, so the call is made directly with the fetch component.
+const DELETION_PATH = '/v1/admin/user/deletion/request'
+const DEFAULT_API_URL = 'https://api.magic.link'
+
+export async function createMagicAdapter({
+  config,
+  logs,
+  fetch
+}: Pick<AppComponents, 'config' | 'logs' | 'fetch'>): Promise<IMagicAdapter> {
+  const logger = logs.getLogger('magic-adapter')
+
+  // Secret key is required and sensitive — never log it or the DID tokens.
+  const secretKey = await config.requireString('MAGIC_SECRET_KEY')
+  const apiUrl = (await config.getString('MAGIC_API_URL')) || DEFAULT_API_URL
+  // Optional: when set, token validation additionally enforces the `aud` claim.
+  const clientId = await config.getString('MAGIC_CLIENT_ID')
+
+  const baseUrl = apiUrl.replace(/\/+$/, '')
+
+  // Constructed (not `Magic.init`) on purpose: the constructor performs no
+  // network call, so token validation stays fully offline and the server has no
+  // startup dependency on Magic. `clientId` enables the offline audience check.
+  const magic = new Magic(secretKey, clientId ? { clientId } : undefined)
+
+  const validateDidToken = (didToken: string): DidTokenValidationResult => {
+    try {
+      magic.token.validate(didToken)
+    } catch (e) {
+      if (e instanceof SDKError && (e.code === ErrorCode.TokenExpired || e.code === ErrorCode.TokenCannotBeUsedYet)) {
+        throw new MagicTokenExpiredError(e.message)
+      }
+      throw new MagicTokenInvalidError(isErrorWithMessage(e) ? e.message : 'Invalid Magic DID token')
+    }
+
+    const [, claim] = magic.token.decode(didToken)
+    const address = magic.token.getPublicAddress(didToken).toLowerCase()
+
+    return { address, issuer: claim.iss, iat: claim.iat, tid: claim.tid }
+  }
+
+  const requestUserDeletion = async (address: string): Promise<MagicDeletionResult> => {
+    const response = await fetch.fetch(`${baseUrl}${DELETION_PATH}`, {
+      method: 'POST',
+      headers: {
+        'X-Magic-Secret-Key': secretKey,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ public_addresses: [address] })
+    })
+
+    if (response.status === 401) {
+      throw new MagicAuthError('Magic rejected the secret key (401)')
+    }
+
+    if (response.status === 429) {
+      throw new MagicRateLimitError('Magic deletion rate limit exceeded (429)')
+    }
+
+    if (!response.ok) {
+      let detail = ''
+      try {
+        detail = (await response.text()).slice(0, 500)
+      } catch {
+        // ignore body read errors
+      }
+      throw new MagicDeletionError(`Magic deletion failed with status ${response.status}${detail ? `: ${detail}` : ''}`)
+    }
+
+    const data = (await response.json()) as Partial<MagicDeletionResult>
+
+    return {
+      processed: Array.isArray(data.processed) ? data.processed : [],
+      unprocessed: Array.isArray(data.unprocessed) ? data.unprocessed : []
+    }
+  }
+
+  logger.log(`Magic adapter ready (apiUrl=${baseUrl}, audienceCheck=${clientId ? 'on' : 'off'})`)
+
+  return { validateDidToken, requestUserDeletion }
+}

--- a/src/adapters/magic/component.ts
+++ b/src/adapters/magic/component.ts
@@ -20,15 +20,15 @@ export async function createMagicAdapter({
   // Secret key is required and sensitive — never log it or the DID tokens.
   const secretKey = await config.requireString('MAGIC_SECRET_KEY')
   const apiUrl = (await config.getString('MAGIC_API_URL')) || DEFAULT_API_URL
-  // Optional: when set, token validation additionally enforces the `aud` claim.
-  const clientId = await config.getString('MAGIC_CLIENT_ID')
+  // Required: token validation enforces the DID token `aud` against this app's client id.
+  const clientId = await config.requireString('MAGIC_CLIENT_ID')
 
   const baseUrl = apiUrl.replace(/\/+$/, '')
 
   // Constructed (not `Magic.init`) on purpose: the constructor performs no
   // network call, so token validation stays fully offline and the server has no
-  // startup dependency on Magic. `clientId` enables the offline audience check.
-  const magic = new Magic(secretKey, clientId ? { clientId } : undefined)
+  // startup dependency on Magic. Passing `clientId` enables the offline audience check.
+  const magic = new Magic(secretKey, { clientId })
 
   const validateDidToken = (didToken: string): DidTokenValidationResult => {
     try {
@@ -82,7 +82,7 @@ export async function createMagicAdapter({
     }
   }
 
-  logger.log(`Magic adapter ready (apiUrl=${baseUrl}, audienceCheck=${clientId ? 'on' : 'off'})`)
+  logger.log(`Magic adapter ready (apiUrl=${baseUrl})`)
 
   return { validateDidToken, requestUserDeletion }
 }

--- a/src/adapters/magic/errors.ts
+++ b/src/adapters/magic/errors.ts
@@ -1,0 +1,48 @@
+/**
+ * The Magic DID token could not be validated (malformed, bad signature, signer
+ * mismatch, or audience mismatch). Maps to HTTP 401.
+ */
+export class MagicTokenInvalidError extends Error {
+  constructor(message = 'Invalid Magic DID token') {
+    super(message)
+    this.name = 'MagicTokenInvalidError'
+  }
+}
+
+/**
+ * The Magic DID token is expired or not yet usable (`ext` / `nbf`).
+ * Maps to HTTP 401.
+ */
+export class MagicTokenExpiredError extends Error {
+  constructor(message = 'Magic DID token has expired') {
+    super(message)
+    this.name = 'MagicTokenExpiredError'
+  }
+}
+
+/**
+ * Magic rejected our secret key when calling the deletion endpoint (HTTP 401
+ * from Magic). This is a server misconfiguration, not a client error.
+ */
+export class MagicAuthError extends Error {
+  constructor(message = 'Magic rejected the secret key') {
+    super(message)
+    this.name = 'MagicAuthError'
+  }
+}
+
+/** Magic returned HTTP 429 for the deletion request. Maps to HTTP 429. */
+export class MagicRateLimitError extends Error {
+  constructor(message = 'Magic deletion rate limit exceeded') {
+    super(message)
+    this.name = 'MagicRateLimitError'
+  }
+}
+
+/** Magic returned an unexpected error for the deletion request. Maps to HTTP 500. */
+export class MagicDeletionError extends Error {
+  constructor(message = 'Magic deletion request failed') {
+    super(message)
+    this.name = 'MagicDeletionError'
+  }
+}

--- a/src/adapters/magic/index.ts
+++ b/src/adapters/magic/index.ts
@@ -1,0 +1,3 @@
+export { createMagicAdapter } from './component'
+export * from './types'
+export * from './errors'

--- a/src/adapters/magic/types.ts
+++ b/src/adapters/magic/types.ts
@@ -1,0 +1,34 @@
+/** Data extracted from a validated Magic DID token. */
+export type DidTokenValidationResult = {
+  /** The wallet public address that issued the token, lowercased (`0x…`). */
+  address: string
+  /** The full issuer DID (`did:ethr:0x…`). */
+  issuer: string
+  /** Issued-at time, epoch seconds. Used to enforce freshness. */
+  iat: number
+  /** Unique token id — used as a one-time-use nonce to prevent replay. */
+  tid: string
+}
+
+/** Response shape of Magic's user deletion endpoint. */
+export type MagicDeletionResult = {
+  /** Identifiers that matched an active user and were queued for deletion. */
+  processed: string[]
+  /** Identifiers that did not match an active user. */
+  unprocessed: string[]
+}
+
+export type IMagicAdapter = {
+  /**
+   * Validates a Magic DID token offline (signature, expiry, `nbf`, and audience
+   * when configured) and returns the issuer address plus replay-protection
+   * fields. Throws `MagicTokenInvalidError` / `MagicTokenExpiredError`.
+   */
+  validateDidToken(didToken: string): DidTokenValidationResult
+  /**
+   * Requests permanent deletion of the user with the given public address via
+   * Magic's GDPR deletion endpoint. Throws `MagicAuthError` /
+   * `MagicRateLimitError` / `MagicDeletionError`.
+   */
+  requestUserDeletion(address: string): Promise<MagicDeletionResult>
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,6 +8,8 @@ import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
 import { createRedisComponent } from '@dcl/redis-component'
 import { createSlackComponent } from '@dcl/slack-component'
 import { createFeatureFlagsAdapter } from './adapters/feature-flags'
+import { createMagicAdapter } from './adapters/magic'
+import { createAccountDeletionComponent } from './logic/account-deletion'
 import { metricDeclarations } from './metrics'
 import { createPgComponent } from './ports/db/component'
 import { createEmailComponent } from './ports/email/component'
@@ -22,6 +24,7 @@ export async function initComponents(): Promise<AppComponents> {
   const config = await createDotEnvConfigComponent({ path: ['.env.default', '.env'] })
   const requestExpirationInSeconds = await config.requireNumber('REQUEST_EXPIRATION_IN_SECONDS')
   const dclPersonalSignExpirationInSeconds = await config.requireNumber('DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS')
+  const didTokenMaxAgeSeconds = await config.requireNumber('MAGIC_DID_TOKEN_MAX_AGE_SECONDS')
   const tracer = await createTracerComponent()
   const logs = await createLogComponent({ tracer })
   const metrics = await createMetricsComponent(metricDeclarations, { config })
@@ -30,12 +33,14 @@ export async function initComponents(): Promise<AppComponents> {
   const db = await createPgComponent({ config, logs, metrics }, {})
   const storage = createStorageComponent({ cache })
   const fetch = createFetchComponent()
+  const magic = await createMagicAdapter({ config, logs, fetch })
   const features = await createFeaturesComponent(
     { config, logs, fetch },
     (await config.getString('SERVICE_BASE_URL')) || 'https://auth-api.decentraland.org'
   )
   const featureFlags = createFeatureFlagsAdapter({ logs, features })
   const onboarding = createOnboardingComponent({ db, logs })
+  const accountDeletion = createAccountDeletionComponent({ magic, storage, onboarding, logs, didTokenMaxAgeSeconds })
   const email = await createEmailComponent({ config, logs })
   const slackToken = await config.getString('SLACK_BOT_TOKEN')
   const slack = createSlackComponent({ logs }, { token: slackToken ?? '' })
@@ -45,6 +50,7 @@ export async function initComponents(): Promise<AppComponents> {
     logs,
     metrics,
     onboarding,
+    accountDeletion,
     email,
     nudgeJob,
     storage,
@@ -59,6 +65,8 @@ export async function initComponents(): Promise<AppComponents> {
     fetch,
     features,
     featureFlags,
+    magic,
+    accountDeletion,
     nudgeJob,
     db,
     email,

--- a/src/components.ts
+++ b/src/components.ts
@@ -40,7 +40,7 @@ export async function initComponents(): Promise<AppComponents> {
   )
   const featureFlags = createFeatureFlagsAdapter({ logs, features })
   const onboarding = createOnboardingComponent({ db, logs })
-  const accountDeletion = createAccountDeletionComponent({ magic, storage, onboarding, logs, didTokenMaxAgeSeconds })
+  const accountDeletion = createAccountDeletionComponent({ magic, storage, logs, didTokenMaxAgeSeconds })
   const email = await createEmailComponent({ config, logs })
   const slackToken = await config.getString('SLACK_BOT_TOKEN')
   const slack = createSlackComponent({ logs }, { token: slackToken ?? '' })

--- a/src/logic/account-deletion/component.ts
+++ b/src/logic/account-deletion/component.ts
@@ -1,0 +1,68 @@
+import { AppComponents } from '../../types'
+import { isErrorWithMessage } from '../error-handling'
+import { AddressMismatchError, DidTokenReusedError, DidTokenStaleError } from './errors'
+import { DeleteAccountParams, DeleteAccountResult, IAccountDeletionComponent } from './types'
+
+// Extra TTL beyond the freshness window kept for the one-time `tid` record, to
+// absorb clock skew between the client and server.
+const TID_TTL_BUFFER_SECONDS = 60
+
+export function createAccountDeletionComponent({
+  magic,
+  storage,
+  onboarding,
+  logs,
+  didTokenMaxAgeSeconds
+}: Pick<AppComponents, 'magic' | 'storage' | 'onboarding' | 'logs'> & {
+  didTokenMaxAgeSeconds: number
+}): IAccountDeletionComponent {
+  const logger = logs.getLogger('account-deletion')
+
+  const deleteAccount = async ({ signedFetchAddress, didToken, ip }: DeleteAccountParams): Promise<DeleteAccountResult> => {
+    // 1. Validate the Magic DID token offline (signature, expiry, audience).
+    //    Throws MagicTokenInvalidError / MagicTokenExpiredError.
+    const { address, iat, tid } = magic.validateDidToken(didToken)
+
+    // 2. The Magic session holder must be the same address that signed the DCL
+    //    request — both layers must agree on one account.
+    if (address !== signedFetchAddress.toLowerCase()) {
+      throw new AddressMismatchError()
+    }
+
+    // 3. The token must have been minted recently, approximating "the user just
+    //    clicked Confirm" and bounding any replay window.
+    const ageSeconds = Math.floor(Date.now() / 1000) - iat
+    if (ageSeconds > didTokenMaxAgeSeconds) {
+      throw new DidTokenStaleError(`DID token is too old (${ageSeconds}s > ${didTokenMaxAgeSeconds}s)`)
+    }
+
+    // 4. One-time use: reject replays of the same token id. Consumed before the
+    //    side-effecting call so a replay cannot trigger a second deletion.
+    const isFresh = await storage.consumeDidTokenId(tid, didTokenMaxAgeSeconds + TID_TTL_BUFFER_SECONDS)
+    if (!isFresh) {
+      throw new DidTokenReusedError()
+    }
+
+    // 5. Permanently delete the Magic account by public address (irreversible).
+    const result = await magic.requestUserDeletion(address)
+
+    // 6. Purge local PII. The irreversible Magic deletion has already happened,
+    //    so a purge failure must not fail the request — log it (idempotent retry).
+    try {
+      await onboarding.deleteByWallet(address)
+    } catch (e) {
+      logger.error(`[ADDR:${address}] Magic account deleted but local purge failed: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
+    }
+
+    // 7. Audit trail for an irreversible action.
+    logger.log(
+      `[ADDR:${address}][IP:${ip ?? 'unknown'}] Account deletion requested via Magic. processed=${result.processed.length} unprocessed=${
+        result.unprocessed.length
+      }`
+    )
+
+    return { address, magic: result }
+  }
+
+  return { deleteAccount }
+}

--- a/src/logic/account-deletion/component.ts
+++ b/src/logic/account-deletion/component.ts
@@ -1,5 +1,4 @@
 import { AppComponents } from '../../types'
-import { isErrorWithMessage } from '../error-handling'
 import { AddressMismatchError, DidTokenReusedError, DidTokenStaleError } from './errors'
 import { DeleteAccountParams, DeleteAccountResult, IAccountDeletionComponent } from './types'
 
@@ -10,10 +9,9 @@ const TID_TTL_BUFFER_SECONDS = 60
 export function createAccountDeletionComponent({
   magic,
   storage,
-  onboarding,
   logs,
   didTokenMaxAgeSeconds
-}: Pick<AppComponents, 'magic' | 'storage' | 'onboarding' | 'logs'> & {
+}: Pick<AppComponents, 'magic' | 'storage' | 'logs'> & {
   didTokenMaxAgeSeconds: number
 }): IAccountDeletionComponent {
   const logger = logs.getLogger('account-deletion')
@@ -43,18 +41,14 @@ export function createAccountDeletionComponent({
       throw new DidTokenReusedError()
     }
 
-    // 5. Permanently delete the Magic account by public address (irreversible).
+    // 5. Request deletion of the user's Magic account by public address.
+    //    This only severs Magic's custodial access — it does NOT delete the wallet
+    //    itself (the user can export the key beforehand), so the address can remain
+    //    an active Decentraland identity. Local onboarding/nudge data is keyed to the
+    //    wallet and is intentionally left intact.
     const result = await magic.requestUserDeletion(address)
 
-    // 6. Purge local PII. The irreversible Magic deletion has already happened,
-    //    so a purge failure must not fail the request — log it (idempotent retry).
-    try {
-      await onboarding.deleteByWallet(address)
-    } catch (e) {
-      logger.error(`[ADDR:${address}] Magic account deleted but local purge failed: ${isErrorWithMessage(e) ? e.message : 'Unknown error'}`)
-    }
-
-    // 7. Audit trail for an irreversible action.
+    // 6. Audit trail.
     logger.log(
       `[ADDR:${address}][IP:${ip ?? 'unknown'}] Account deletion requested via Magic. processed=${result.processed.length} unprocessed=${
         result.unprocessed.length

--- a/src/logic/account-deletion/errors.ts
+++ b/src/logic/account-deletion/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * The address recovered from the Magic DID token does not match the address that
+ * signed the DCL signed-fetch request. Maps to HTTP 403.
+ */
+export class AddressMismatchError extends Error {
+  constructor(message = 'DID token address does not match the request signer') {
+    super(message)
+    this.name = 'AddressMismatchError'
+  }
+}
+
+/**
+ * The DID token was not minted recently enough to be considered a deliberate,
+ * fresh deletion action. Maps to HTTP 403.
+ */
+export class DidTokenStaleError extends Error {
+  constructor(message = 'DID token is stale') {
+    super(message)
+    this.name = 'DidTokenStaleError'
+  }
+}
+
+/**
+ * The DID token id (`tid`) has already been used — replay attempt. Maps to HTTP 403.
+ */
+export class DidTokenReusedError extends Error {
+  constructor(message = 'DID token has already been used') {
+    super(message)
+    this.name = 'DidTokenReusedError'
+  }
+}

--- a/src/logic/account-deletion/index.ts
+++ b/src/logic/account-deletion/index.ts
@@ -1,0 +1,3 @@
+export { createAccountDeletionComponent } from './component'
+export * from './types'
+export * from './errors'

--- a/src/logic/account-deletion/types.ts
+++ b/src/logic/account-deletion/types.ts
@@ -1,0 +1,26 @@
+import { MagicDeletionResult } from '../../adapters/magic'
+
+export type DeleteAccountParams = {
+  /** Address recovered from the DCL signed-fetch request (`req.auth`). */
+  signedFetchAddress: string
+  /** Freshly-minted Magic DID token proving a current Magic session. */
+  didToken: string
+  /** Client IP, for the audit log. */
+  ip?: string
+}
+
+export type DeleteAccountResult = {
+  /** The deleted wallet address (lowercased). */
+  address: string
+  /** Raw result from Magic's deletion endpoint. */
+  magic: MagicDeletionResult
+}
+
+export type IAccountDeletionComponent = {
+  /**
+   * Validates the caller (DID token + signed-fetch cross-check + freshness +
+   * one-time use), permanently deletes the Magic account by public address, and
+   * purges local PII. Throws typed errors that the controller maps to HTTP codes.
+   */
+  deleteAccount(params: DeleteAccountParams): Promise<DeleteAccountResult>
+}

--- a/src/ports/onboarding/component.ts
+++ b/src/ports/onboarding/component.ts
@@ -143,29 +143,9 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
     logger.log(`[CP:${checkpointId}][USER:${userId}][SEQ:${sequence}] Nudge marked as sent`)
   }
 
-  const deleteByWallet = async (address: string): Promise<void> => {
-    const wallet = address.toLowerCase()
-
-    // Delete nudges first (no FK constraint enforces ordering, so do it
-    // explicitly) for every user_id linked to this wallet.
-    await db.query(SQL`
-      DELETE FROM email_nudges
-      WHERE user_id IN (
-        SELECT user_id FROM onboarding_checkpoints WHERE wallet = ${wallet}
-      )
-    `)
-
-    const result = await db.query(SQL`
-      DELETE FROM onboarding_checkpoints WHERE wallet = ${wallet}
-    `)
-
-    logger.log(`[WALLET:${wallet}] Purged ${result.rowCount ?? 0} onboarding checkpoint row(s) and related nudges`)
-  }
-
   return {
     recordCheckpoint,
     getPendingNudges,
-    markNudgeSent,
-    deleteByWallet
+    markNudgeSent
   }
 }

--- a/src/ports/onboarding/component.ts
+++ b/src/ports/onboarding/component.ts
@@ -143,9 +143,29 @@ export function createOnboardingComponent({ db, logs }: Pick<AppComponents, 'db'
     logger.log(`[CP:${checkpointId}][USER:${userId}][SEQ:${sequence}] Nudge marked as sent`)
   }
 
+  const deleteByWallet = async (address: string): Promise<void> => {
+    const wallet = address.toLowerCase()
+
+    // Delete nudges first (no FK constraint enforces ordering, so do it
+    // explicitly) for every user_id linked to this wallet.
+    await db.query(SQL`
+      DELETE FROM email_nudges
+      WHERE user_id IN (
+        SELECT user_id FROM onboarding_checkpoints WHERE wallet = ${wallet}
+      )
+    `)
+
+    const result = await db.query(SQL`
+      DELETE FROM onboarding_checkpoints WHERE wallet = ${wallet}
+    `)
+
+    logger.log(`[WALLET:${wallet}] Purged ${result.rowCount ?? 0} onboarding checkpoint row(s) and related nudges`)
+  }
+
   return {
     recordCheckpoint,
     getPendingNudges,
-    markNudgeSent
+    markNudgeSent,
+    deleteByWallet
   }
 }

--- a/src/ports/onboarding/types.ts
+++ b/src/ports/onboarding/types.ts
@@ -24,4 +24,10 @@ export type IOnboardingComponent = IBaseComponent & {
   recordCheckpoint(payload: CheckpointPayload): Promise<void>
   getPendingNudges(sequence: 1 | 2 | 3): Promise<PendingNudge[]>
   markNudgeSent(userId: string, checkpointId: number, sequence: number, messageId?: string): Promise<void>
+  /**
+   * Permanently deletes all locally-stored onboarding data (checkpoints and
+   * email nudges) for the given wallet address. Idempotent. Used to purge local
+   * PII when a user deletes their account.
+   */
+  deleteByWallet(address: string): Promise<void>
 }

--- a/src/ports/onboarding/types.ts
+++ b/src/ports/onboarding/types.ts
@@ -24,10 +24,4 @@ export type IOnboardingComponent = IBaseComponent & {
   recordCheckpoint(payload: CheckpointPayload): Promise<void>
   getPendingNudges(sequence: 1 | 2 | 3): Promise<PendingNudge[]>
   markNudgeSent(userId: string, checkpointId: number, sequence: number, messageId?: string): Promise<void>
-  /**
-   * Permanently deletes all locally-stored onboarding data (checkpoints and
-   * email nudges) for the given wallet address. Idempotent. Used to purge local
-   * PII when a user deletes their account.
-   */
-  deleteByWallet(address: string): Promise<void>
 }

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -10,6 +10,8 @@ import { v4 as uuid } from 'uuid'
 import { Authenticator, parseEmphemeralPayload } from '@dcl/crypto'
 import { AuthChain } from '@dcl/schemas'
 import { express as authMiddleware, DecentralandSignatureData } from 'decentraland-crypto-middleware'
+import { MagicRateLimitError, MagicTokenExpiredError, MagicTokenInvalidError } from '../../adapters/magic'
+import { AddressMismatchError, DidTokenReusedError, DidTokenStaleError } from '../../logic/account-deletion'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { AppComponents } from '../../types'
 import { METHOD_DCL_PERSONAL_SIGN, ONE_HOUR_IN_MILLISECONDS, MAX_BODY_SIZE } from './constants'
@@ -28,7 +30,9 @@ import {
   RequestMessage,
   RequestResponseMessage,
   RequestValidationMessage,
-  RequestValidationStatusMessage
+  RequestValidationStatusMessage,
+  AccountDeletionRequest,
+  AccountDeletionResponse
 } from './types'
 import {
   validateHttpOutcomeMessage,
@@ -38,7 +42,8 @@ import {
   validateRequestValidationMessage,
   validateIdentityId,
   validateIdentityRequest,
-  validateCheckpointRequest
+  validateCheckpointRequest,
+  validateAccountDeletionRequest
 } from './validations'
 
 export async function createServerComponent({
@@ -46,13 +51,14 @@ export async function createServerComponent({
   logs,
   metrics,
   onboarding,
+  accountDeletion,
   email,
   nudgeJob,
   storage,
   tracer,
   requestExpirationInSeconds,
   dclPersonalSignExpirationInSeconds
-}: Pick<AppComponents, 'config' | 'logs' | 'metrics' | 'onboarding' | 'email' | 'nudgeJob' | 'storage' | 'tracer'> & {
+}: Pick<AppComponents, 'config' | 'logs' | 'metrics' | 'onboarding' | 'accountDeletion' | 'email' | 'nudgeJob' | 'storage' | 'tracer'> & {
   requestExpirationInSeconds: number
   dclPersonalSignExpirationInSeconds: number
 }): Promise<IServerComponent> {
@@ -68,6 +74,15 @@ export async function createServerComponent({
     origin: (await config.requireString('CORS_ORIGIN')).split(';').map(origin => new RegExp(origin)),
     methods: await config.requireString('CORS_METHODS')
   }
+
+  // Exact-match allowlist of browser Origins permitted to call the account
+  // deletion endpoint (defense-in-depth on top of CORS). Empty disables the check.
+  const accountDeletionAllowedOrigins = new Set(
+    ((await config.getString('ACCOUNT_DELETION_ALLOWED_ORIGINS')) || '')
+      .split(';')
+      .map(origin => origin.trim().toLowerCase())
+      .filter(origin => origin.length > 0)
+  )
 
   // Metrics configuration
   const metricsPath = (await config.getString('WKC_METRICS_PUBLIC_PATH')) || '/metrics'
@@ -1030,6 +1045,81 @@ export async function createServerComponent({
           return sendResponse<InvalidResponseMessage>(res, 400, {
             error: errorMessage
           })
+        }
+      }
+    )
+
+    // Account deletion endpoint — permanently deletes the user's Magic account
+    // (irreversible) and purges local PII. Layered auth: DCL signed-fetch
+    // (req.auth) + a fresh Magic DID token, cross-checked to the same address.
+    app.delete(
+      '/accounts',
+      authMiddleware({
+        optional: false,
+        onError: err => ({
+          error: err.message,
+          message: 'This endpoint requires a signed fetch request. See ADR-44.'
+        }),
+        verifyMetadataContent: metadata => metadata?.signer !== 'decentraland-kernel-scene' // prevent requests from scenes
+      }),
+      async (req: Request & DecentralandSignatureData) => {
+        const res = req.res as Response
+        const deletionLogger = logs.getLogger('account-deletion-endpoint')
+
+        // Defense-in-depth: restrict to official Decentraland browser origins.
+        const origin = (req.headers.origin || '').toLowerCase()
+        if (accountDeletionAllowedOrigins.size > 0 && (!origin || !accountDeletionAllowedOrigins.has(origin))) {
+          deletionLogger.log(`Rejected account deletion from disallowed origin: ${req.headers.origin ?? 'none'}`)
+          return sendResponse<InvalidResponseMessage>(res, 403, { error: 'Origin not allowed' })
+        }
+
+        let body: AccountDeletionRequest
+        try {
+          body = validateAccountDeletionRequest(req.body)
+        } catch (e) {
+          return sendResponse<InvalidResponseMessage>(res, 400, {
+            error: isErrorWithMessage(e) ? e.message : 'Unknown error'
+          })
+        }
+
+        const requestSender = req.auth
+        if (!requestSender) {
+          return sendResponse<InvalidResponseMessage>(res, 401, { error: 'Request signer is required' })
+        }
+
+        try {
+          const result = await accountDeletion.deleteAccount({
+            signedFetchAddress: requestSender,
+            didToken: body.didToken,
+            ip: getClientIp(req)
+          })
+
+          return sendResponse<AccountDeletionResponse>(res, 200, {
+            deleted: true,
+            address: result.address,
+            magic: result.magic
+          })
+        } catch (e) {
+          const message = isErrorWithMessage(e) ? e.message : 'Unknown error'
+
+          if (e instanceof MagicTokenInvalidError || e instanceof MagicTokenExpiredError) {
+            deletionLogger.log(`Rejected account deletion: invalid DID token: ${message}`)
+            return sendResponse<InvalidResponseMessage>(res, 401, { error: message })
+          }
+
+          if (e instanceof AddressMismatchError || e instanceof DidTokenStaleError || e instanceof DidTokenReusedError) {
+            deletionLogger.log(`Rejected account deletion: ${message}`)
+            return sendResponse<InvalidResponseMessage>(res, 403, { error: message })
+          }
+
+          if (e instanceof MagicRateLimitError) {
+            deletionLogger.log(`Account deletion rate limited by Magic: ${message}`)
+            return sendResponse<InvalidResponseMessage>(res, 429, { error: message })
+          }
+
+          // MagicAuthError (our misconfig), MagicDeletionError, and anything else.
+          deletionLogger.error(`Account deletion failed: ${message}`)
+          return sendResponse<InvalidResponseMessage>(res, 500, { error: 'Internal server error' })
         }
       }
     )

--- a/src/ports/server/component.ts
+++ b/src/ports/server/component.ts
@@ -31,7 +31,7 @@ import {
   RequestResponseMessage,
   RequestValidationMessage,
   RequestValidationStatusMessage,
-  AccountDeletionRequest,
+  AccountDeletionMetadata,
   AccountDeletionResponse
 } from './types'
 import {
@@ -43,7 +43,7 @@ import {
   validateIdentityId,
   validateIdentityRequest,
   validateCheckpointRequest,
-  validateAccountDeletionRequest
+  validateAccountDeletionMetadata
 } from './validations'
 
 export async function createServerComponent({
@@ -1073,9 +1073,11 @@ export async function createServerComponent({
           return sendResponse<InvalidResponseMessage>(res, 403, { error: 'Origin not allowed' })
         }
 
-        let body: AccountDeletionRequest
+        // The DID token travels in the signed-fetch metadata, so it is covered by
+        // the request signature (method:path:timestamp:metadata) — no request body.
+        let metadata: AccountDeletionMetadata
         try {
-          body = validateAccountDeletionRequest(req.body)
+          metadata = validateAccountDeletionMetadata(req.authMetadata)
         } catch (e) {
           return sendResponse<InvalidResponseMessage>(res, 400, {
             error: isErrorWithMessage(e) ? e.message : 'Unknown error'
@@ -1090,7 +1092,7 @@ export async function createServerComponent({
         try {
           const result = await accountDeletion.deleteAccount({
             signedFetchAddress: requestSender,
-            didToken: body.didToken,
+            didToken: metadata.didToken,
             ip: getClientIp(req)
           })
 

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -101,7 +101,7 @@ export type CheckpointRequest = {
   metadata?: Record<string, unknown>
 }
 
-export type AccountDeletionRequest = {
+export type AccountDeletionMetadata = {
   didToken: string
 }
 

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -101,6 +101,19 @@ export type CheckpointRequest = {
   metadata?: Record<string, unknown>
 }
 
+export type AccountDeletionRequest = {
+  didToken: string
+}
+
+export type AccountDeletionResponse = {
+  deleted: boolean
+  address: string
+  magic: {
+    processed: string[]
+    unprocessed: string[]
+  }
+}
+
 export type InputMessage = RequestMessage | RecoverMessage | OutcomeMessage | IdentityRequest
 
 export type ResponseMessage = RequestResponseMessage | RecoverResponseMessage | OutcomeResponseMessage | InvalidResponseMessage

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -10,7 +10,7 @@ import {
   RequestValidationMessage,
   IdentityRequest,
   CheckpointRequest,
-  AccountDeletionRequest
+  AccountDeletionMetadata
 } from './types'
 
 const ajv = new Ajv({ allowUnionTypes: true })
@@ -177,7 +177,7 @@ const checkpointRequestSchema = {
   additionalProperties: false
 }
 
-const accountDeletionRequestSchema = {
+const accountDeletionMetadataSchema = {
   type: 'object',
   properties: {
     didToken: {
@@ -187,7 +187,8 @@ const accountDeletionRequestSchema = {
     }
   },
   required: ['didToken'],
-  additionalProperties: false
+  // Signed-fetch metadata may carry other fields (e.g. signer) alongside the token.
+  additionalProperties: true
 }
 
 const requestMessageValidator = ajv.compile(requestMessageSchema)
@@ -197,7 +198,7 @@ const httpOutcomeMessageValidator = ajv.compile(httpOutcomeMessageSchema)
 const requestValidationMessageValidator = ajv.compile(requestValidationMessageSchema)
 const identityIdRequestValidator = ajv.compile(identityRequestSchema)
 const checkpointRequestValidator = ajv.compile(checkpointRequestSchema)
-const accountDeletionRequestValidator = ajv.compile(accountDeletionRequestSchema)
+const accountDeletionMetadataValidator = ajv.compile(accountDeletionMetadataSchema)
 
 export function validateRequestMessage(msg: unknown) {
   if (!requestMessageValidator(msg)) {
@@ -265,10 +266,10 @@ export function validateCheckpointRequest(msg: unknown) {
   return msg as CheckpointRequest
 }
 
-export function validateAccountDeletionRequest(msg: unknown) {
-  if (!accountDeletionRequestValidator(msg)) {
-    throw new Error(JSON.stringify(accountDeletionRequestValidator.errors))
+export function validateAccountDeletionMetadata(msg: unknown) {
+  if (!accountDeletionMetadataValidator(msg)) {
+    throw new Error(JSON.stringify(accountDeletionMetadataValidator.errors))
   }
 
-  return msg as AccountDeletionRequest
+  return msg as AccountDeletionMetadata
 }

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -9,7 +9,8 @@ import {
   RequestMessage,
   RequestValidationMessage,
   IdentityRequest,
-  CheckpointRequest
+  CheckpointRequest,
+  AccountDeletionRequest
 } from './types'
 
 const ajv = new Ajv({ allowUnionTypes: true })
@@ -176,6 +177,19 @@ const checkpointRequestSchema = {
   additionalProperties: false
 }
 
+const accountDeletionRequestSchema = {
+  type: 'object',
+  properties: {
+    didToken: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 4096
+    }
+  },
+  required: ['didToken'],
+  additionalProperties: false
+}
+
 const requestMessageValidator = ajv.compile(requestMessageSchema)
 const recoverMessageValidator = ajv.compile(recoverMessageSchema)
 const outcomeMessageValidator = ajv.compile(outcomeMessageSchema)
@@ -183,6 +197,7 @@ const httpOutcomeMessageValidator = ajv.compile(httpOutcomeMessageSchema)
 const requestValidationMessageValidator = ajv.compile(requestValidationMessageSchema)
 const identityIdRequestValidator = ajv.compile(identityRequestSchema)
 const checkpointRequestValidator = ajv.compile(checkpointRequestSchema)
+const accountDeletionRequestValidator = ajv.compile(accountDeletionRequestSchema)
 
 export function validateRequestMessage(msg: unknown) {
   if (!requestMessageValidator(msg)) {
@@ -248,4 +263,12 @@ export function validateCheckpointRequest(msg: unknown) {
   }
 
   return msg as CheckpointRequest
+}
+
+export function validateAccountDeletionRequest(msg: unknown) {
+  if (!accountDeletionRequestValidator(msg)) {
+    throw new Error(JSON.stringify(accountDeletionRequestValidator.errors))
+  }
+
+  return msg as AccountDeletionRequest
 }

--- a/src/ports/storage/component.ts
+++ b/src/ports/storage/component.ts
@@ -5,6 +5,7 @@ const REQUESTS_CACHE_KEY_PREFIX = 'request:'
 const REQUEST_IDS_BY_SOCKET_ID_CACHE_KEY_PREFIX = 'requestIdsBySocketId:'
 const IDENTITIES_BY_ID_CACHE_KEY_PREFIX = 'identity:'
 const IDENTITY_STATUS_CACHE_KEY_PREFIX = 'identity-status:'
+const DID_TOKEN_ID_CACHE_KEY_PREFIX = 'magic-did-tid:'
 const TWO_WEEKS_IN_SECONDS = 14 * 24 * 60 * 60
 
 /** Normalize cache value to Date (Redis/JSON returns string; in-memory may return Date). */
@@ -116,6 +117,16 @@ export function createStorageComponent({ cache }: Pick<AppComponents, 'cache'>):
     await cache.set(getIdentityStatusCacheKey(identityId), { ...existing, ...updates }, TWO_WEEKS_IN_SECONDS)
   }
 
+  const consumeDidTokenId = async (tid: string, ttlSeconds: number): Promise<boolean> => {
+    const key = `${DID_TOKEN_ID_CACHE_KEY_PREFIX}${tid}`
+    const existing = await cache.get<boolean>(key)
+    if (existing) {
+      return false
+    }
+    await cache.set(key, true, Math.max(1, Math.ceil(ttlSeconds)))
+    return true
+  }
+
   return {
     getRequest,
     setRequest,
@@ -125,6 +136,7 @@ export function createStorageComponent({ cache }: Pick<AppComponents, 'cache'>):
     deleteIdentity,
     getIdentityStatus,
     setIdentityStatus,
-    updateIdentityStatus
+    updateIdentityStatus,
+    consumeDidTokenId
   }
 }

--- a/src/ports/storage/types.ts
+++ b/src/ports/storage/types.ts
@@ -11,6 +11,12 @@ export type IStorageComponent = {
   getIdentityStatus(identityId: string): Promise<IdentityStatus | null>
   setIdentityStatus(identityId: string, status: IdentityStatus): Promise<void>
   updateIdentityStatus(identityId: string, updates: Partial<IdentityStatus>): Promise<void>
+  /**
+   * Marks a Magic DID token id (`tid`) as used. Returns `true` if it was not
+   * seen before (and is now recorded for `ttlSeconds`), `false` if it was
+   * already used — enabling one-time-use enforcement to prevent replay.
+   */
+  consumeDidTokenId(tid: string, ttlSeconds: number): Promise<boolean>
 }
 
 export type StorageRequest = Request & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import type { ICacheStorageComponent } from '@dcl/core-commons'
 import type { ISlackComponent } from '@dcl/slack-component'
 import type { IFeatureFlagsAdapter } from './adapters/feature-flags'
+import type { IMagicAdapter } from './adapters/magic'
+import type { IAccountDeletionComponent } from './logic/account-deletion'
 import type { metricDeclarations } from './metrics'
 import type { IPgComponent } from './ports/db/types'
 import type { IEmailComponent } from './ports/email/types'
@@ -27,6 +29,8 @@ export type BaseComponents = {
   fetch: IFetchComponent
   features: IFeaturesComponent
   featureFlags: IFeatureFlagsAdapter
+  magic: IMagicAdapter
+  accountDeletion: IAccountDeletionComponent
   nudgeJob: INudgeJobComponent
   db: IPgComponent
   email: IEmailComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -10,6 +10,8 @@ import { createRunner } from '@well-known-components/test-helpers'
 import { createTracerComponent } from '@well-known-components/tracer-component'
 import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
 import { ISlackComponent } from '@dcl/slack-component'
+import { IMagicAdapter } from '../src/adapters/magic'
+import { createAccountDeletionComponent } from '../src/logic/account-deletion'
 import { metricDeclarations } from '../src/metrics'
 import { IPgComponent } from '../src/ports/db/types'
 import { IEmailComponent } from '../src/ports/email/types'
@@ -23,6 +25,7 @@ import { TestComponents } from '../src/types'
 type TestOverrides = {
   requestExpirationInSeconds?: number
   dclPersonalSignExpirationInSeconds?: number
+  didTokenMaxAgeSeconds?: number
 }
 
 /**
@@ -75,6 +78,17 @@ function createMockLogs(): ILoggerComponent {
 }
 
 /**
+ * Creates a mock Magic adapter. Tests control its behavior per-case via
+ * `args.components.magic.validateDidToken` / `requestUserDeletion`.
+ */
+export function createMockMagicAdapter(): IMagicAdapter {
+  return {
+    validateDidToken: jest.fn(),
+    requestUserDeletion: jest.fn().mockResolvedValue({ processed: [], unprocessed: [] })
+  } as unknown as IMagicAdapter
+}
+
+/**
  * Behaves like Jest "describe" function, used to describe a test for a
  * use case, it creates a whole new program and components to run an
  * isolated test.
@@ -100,7 +114,11 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
 
   const config = await createDotEnvConfigComponent(
     { path: [path.resolve(__dirname, '../.env.spec')] },
-    { HTTP_SERVER_PORT: httpServerPort.toString(), CORS_ORIGIN: 'https://test-*.org;https://test-*.zone' }
+    {
+      HTTP_SERVER_PORT: httpServerPort.toString(),
+      CORS_ORIGIN: 'https://test-*.org;https://test-*.zone',
+      ACCOUNT_DELETION_ALLOWED_ORIGINS: 'https://account.decentraland.org'
+    }
   )
 
   const tracer = await createTracerComponent()
@@ -110,6 +128,14 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
   const db = createMockDbComponent()
   const storage = createStorageComponent({ cache })
   const onboarding = createOnboardingComponent({ db, logs })
+  const magic = createMockMagicAdapter()
+  const accountDeletion = createAccountDeletionComponent({
+    magic,
+    storage,
+    onboarding,
+    logs,
+    didTokenMaxAgeSeconds: overrides.didTokenMaxAgeSeconds ?? 120
+  })
   const email = createMockEmailComponent()
   const slack: ISlackComponent = {
     sendMessage: jest.fn().mockResolvedValue(undefined)
@@ -128,6 +154,7 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
     logs,
     metrics,
     onboarding,
+    accountDeletion,
     email,
     nudgeJob,
     tracer,
@@ -141,6 +168,8 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
     fetch,
     features,
     featureFlags,
+    magic,
+    accountDeletion,
     nudgeJob,
     db,
     email,

--- a/test/components.ts
+++ b/test/components.ts
@@ -132,7 +132,6 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
   const accountDeletion = createAccountDeletionComponent({
     magic,
     storage,
-    onboarding,
     logs,
     didTokenMaxAgeSeconds: overrides.didTokenMaxAgeSeconds ?? 120
   })

--- a/test/integration/account-deletion.spec.ts
+++ b/test/integration/account-deletion.spec.ts
@@ -36,7 +36,7 @@ test('when deleting a Magic account', args => {
       const response = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -50,7 +50,7 @@ test('when deleting a Magic account', args => {
       await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -64,7 +64,7 @@ test('when deleting a Magic account', args => {
       await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -95,7 +95,7 @@ test('when deleting a Magic account', args => {
       const first = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -104,7 +104,7 @@ test('when deleting a Magic account', args => {
       const second = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -133,7 +133,7 @@ test('when deleting a Magic account', args => {
       const response = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -160,7 +160,7 @@ test('when deleting a Magic account', args => {
       const response = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken: 'invalid' },
+        metadata: { didToken: 'invalid' },
         identity,
         headers: { origin: allowedOrigin }
       })
@@ -191,7 +191,7 @@ test('when deleting a Magic account', args => {
       const response = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: 'https://evil.example.com' }
       })
@@ -205,7 +205,7 @@ test('when deleting a Magic account', args => {
       await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: { didToken },
+        metadata: { didToken },
         identity,
         headers: { origin: 'https://evil.example.com' }
       })
@@ -228,7 +228,7 @@ test('when deleting a Magic account', args => {
     })
   })
 
-  describe('and the body is missing the DID token', () => {
+  describe('and the DID token is missing from the metadata', () => {
     let identity: AuthIdentity
 
     beforeEach(async () => {
@@ -239,7 +239,7 @@ test('when deleting a Magic account', args => {
       const response = await createSignedFetchRequest(baseUrl, {
         method: 'DELETE',
         path: '/accounts',
-        body: {},
+        metadata: {},
         identity,
         headers: { origin: allowedOrigin }
       })

--- a/test/integration/account-deletion.spec.ts
+++ b/test/integration/account-deletion.spec.ts
@@ -29,7 +29,6 @@ test('when deleting a Magic account', args => {
       magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
       magic.validateDidToken.mockReturnValue({ address: signer, issuer: `did:ethr:${signer}`, iat: Math.floor(Date.now() / 1000), tid })
       magic.requestUserDeletion.mockResolvedValue({ processed: [signer], unprocessed: [] })
-      ;(args.components.db.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0, notices: [] })
     })
 
     it('should respond with 200 and report the deletion result', async () => {
@@ -57,20 +56,6 @@ test('when deleting a Magic account', args => {
 
       expect(magic.requestUserDeletion).toHaveBeenCalledWith(signer)
     })
-
-    it('should purge local onboarding data for the address', async () => {
-      const spy = jest.spyOn(args.components.onboarding, 'deleteByWallet')
-
-      await createSignedFetchRequest(baseUrl, {
-        method: 'DELETE',
-        path: '/accounts',
-        metadata: { didToken },
-        identity,
-        headers: { origin: allowedOrigin }
-      })
-
-      expect(spy).toHaveBeenCalledWith(signer)
-    })
   })
 
   describe('and the same DID token is used twice', () => {
@@ -88,7 +73,6 @@ test('when deleting a Magic account', args => {
       magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
       magic.validateDidToken.mockReturnValue({ address: signer, issuer: `did:ethr:${signer}`, iat: Math.floor(Date.now() / 1000), tid })
       magic.requestUserDeletion.mockResolvedValue({ processed: [signer], unprocessed: [] })
-      ;(args.components.db.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0, notices: [] })
     })
 
     it('should respond with 403 on the second attempt', async () => {

--- a/test/integration/account-deletion.spec.ts
+++ b/test/integration/account-deletion.spec.ts
@@ -1,0 +1,250 @@
+import { Authenticator, AuthIdentity } from '@dcl/crypto'
+import { IMagicAdapter, MagicTokenInvalidError } from '../../src/adapters/magic'
+import { test } from '../components'
+import { createSignedFetchRequest } from '../utils/signed-request'
+import { createTestIdentity, generateRandomIdentityId } from '../utils/test-identity'
+
+test('when deleting a Magic account', args => {
+  let baseUrl: string
+  let allowedOrigin: string
+
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    baseUrl = `http://localhost:${port}`
+    allowedOrigin = 'https://account.decentraland.org'
+  })
+
+  describe('and the request is a valid signed fetch with a fresh DID token from an allowed origin', () => {
+    let identity: AuthIdentity
+    let signer: string
+    let didToken: string
+    let tid: string
+    let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      signer = Authenticator.ownerAddress(identity.authChain).toLowerCase()
+      tid = generateRandomIdentityId()
+      didToken = `did-token-${tid}`
+      magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+      magic.validateDidToken.mockReturnValue({ address: signer, issuer: `did:ethr:${signer}`, iat: Math.floor(Date.now() / 1000), tid })
+      magic.requestUserDeletion.mockResolvedValue({ processed: [signer], unprocessed: [] })
+      ;(args.components.db.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0, notices: [] })
+    })
+
+    it('should respond with 200 and report the deletion result', async () => {
+      const response = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(response.status).toBe(200)
+      const responseBody = await response.json()
+      expect(responseBody).toEqual({ deleted: true, address: signer, magic: { processed: [signer], unprocessed: [] } })
+    })
+
+    it('should request the deletion from Magic with the recovered address', async () => {
+      await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(magic.requestUserDeletion).toHaveBeenCalledWith(signer)
+    })
+
+    it('should purge local onboarding data for the address', async () => {
+      const spy = jest.spyOn(args.components.onboarding, 'deleteByWallet')
+
+      await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(spy).toHaveBeenCalledWith(signer)
+    })
+  })
+
+  describe('and the same DID token is used twice', () => {
+    let identity: AuthIdentity
+    let signer: string
+    let didToken: string
+    let tid: string
+    let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      signer = Authenticator.ownerAddress(identity.authChain).toLowerCase()
+      tid = generateRandomIdentityId()
+      didToken = `did-token-${tid}`
+      magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+      magic.validateDidToken.mockReturnValue({ address: signer, issuer: `did:ethr:${signer}`, iat: Math.floor(Date.now() / 1000), tid })
+      magic.requestUserDeletion.mockResolvedValue({ processed: [signer], unprocessed: [] })
+      ;(args.components.db.query as jest.Mock).mockResolvedValue({ rows: [], rowCount: 0, notices: [] })
+    })
+
+    it('should respond with 403 on the second attempt', async () => {
+      const first = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+      expect(first.status).toBe(200)
+
+      const second = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+      expect(second.status).toBe(403)
+    })
+  })
+
+  describe('and the DID token address does not match the request signer', () => {
+    let identity: AuthIdentity
+    let didToken: string
+    let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      didToken = `did-token-${generateRandomIdentityId()}`
+      magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+      magic.validateDidToken.mockReturnValue({
+        address: '0x1111111111111111111111111111111111111111',
+        issuer: 'did:ethr:0x1111111111111111111111111111111111111111',
+        iat: Math.floor(Date.now() / 1000),
+        tid: generateRandomIdentityId()
+      })
+    })
+
+    it('should respond with 403 and an address mismatch error', async () => {
+      const response = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(response.status).toBe(403)
+      const responseBody = await response.json()
+      expect(responseBody.error).toContain('does not match')
+    })
+  })
+
+  describe('and the DID token is invalid', () => {
+    let identity: AuthIdentity
+    let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+      magic.validateDidToken.mockImplementation(() => {
+        throw new MagicTokenInvalidError()
+      })
+    })
+
+    it('should respond with 401', async () => {
+      const response = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken: 'invalid' },
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('and the origin is not allowed', () => {
+    let identity: AuthIdentity
+    let didToken: string
+    let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      const signer = Authenticator.ownerAddress(identity.authChain).toLowerCase()
+      didToken = `did-token-${generateRandomIdentityId()}`
+      magic = args.components.magic as jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+      magic.validateDidToken.mockReturnValue({
+        address: signer,
+        issuer: `did:ethr:${signer}`,
+        iat: Math.floor(Date.now() / 1000),
+        tid: generateRandomIdentityId()
+      })
+    })
+
+    it('should respond with 403 and an origin not allowed error', async () => {
+      const response = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: 'https://evil.example.com' }
+      })
+
+      expect(response.status).toBe(403)
+      const responseBody = await response.json()
+      expect(responseBody).toEqual({ error: 'Origin not allowed' })
+    })
+
+    it('should not request the deletion from Magic', async () => {
+      await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: { didToken },
+        identity,
+        headers: { origin: 'https://evil.example.com' }
+      })
+
+      expect(magic.requestUserDeletion).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the request is not a signed fetch', () => {
+    it('should respond requiring a signed fetch request', async () => {
+      const response = await fetch(`${baseUrl}/accounts`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', origin: 'https://account.decentraland.org' },
+        body: JSON.stringify({ didToken: 'whatever' })
+      })
+
+      expect(response.status).toBe(400)
+      const responseBody = await response.json()
+      expect(responseBody.message).toBe('This endpoint requires a signed fetch request. See ADR-44.')
+    })
+  })
+
+  describe('and the body is missing the DID token', () => {
+    let identity: AuthIdentity
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+    })
+
+    it('should respond with 400', async () => {
+      const response = await createSignedFetchRequest(baseUrl, {
+        method: 'DELETE',
+        path: '/accounts',
+        body: {},
+        identity,
+        headers: { origin: allowedOrigin }
+      })
+
+      expect(response.status).toBe(400)
+    })
+  })
+})

--- a/test/unit/account-deletion.spec.ts
+++ b/test/unit/account-deletion.spec.ts
@@ -1,0 +1,163 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
+import { IMagicAdapter, MagicRateLimitError } from '../../src/adapters/magic'
+import { createAccountDeletionComponent } from '../../src/logic/account-deletion/component'
+import { AddressMismatchError, DidTokenReusedError, DidTokenStaleError } from '../../src/logic/account-deletion/errors'
+import { IAccountDeletionComponent } from '../../src/logic/account-deletion/types'
+import { IOnboardingComponent } from '../../src/ports/onboarding/types'
+import { createStorageComponent } from '../../src/ports/storage/component'
+import { IStorageComponent } from '../../src/ports/storage/types'
+
+function createMockLogs(): ILoggerComponent {
+  const logger = { log: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() }
+  return { getLogger: () => logger } as unknown as ILoggerComponent
+}
+
+describe('when deleting an account', () => {
+  let accountDeletion: IAccountDeletionComponent
+  let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
+  let onboarding: jest.Mocked<Pick<IOnboardingComponent, 'deleteByWallet'>>
+  let storage: IStorageComponent
+  let address: string
+  let signedFetchAddress: string
+  let didToken: string
+  let tid: string
+  let nowSeconds: number
+
+  beforeEach(() => {
+    address = '0xaabbccddeeff00112233445566778899aabbccdd'
+    // Same address as `address` but checksum-cased, to exercise case-insensitive matching.
+    signedFetchAddress = '0xAABBCCDDEEFF00112233445566778899AABBCCDD'
+    nowSeconds = Math.floor(Date.now() / 1000)
+    tid = 'tid-abc'
+    didToken = 'did-token'
+
+    magic = {
+      validateDidToken: jest.fn(),
+      requestUserDeletion: jest.fn()
+    }
+    onboarding = { deleteByWallet: jest.fn().mockResolvedValue(undefined) }
+    storage = createStorageComponent({ cache: createInMemoryCacheComponent() })
+
+    accountDeletion = createAccountDeletionComponent({
+      magic: magic as unknown as IMagicAdapter,
+      storage,
+      onboarding: onboarding as unknown as IOnboardingComponent,
+      logs: createMockLogs(),
+      didTokenMaxAgeSeconds: 120
+    })
+  })
+
+  describe('and the DID token is valid and matches the signer', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds, tid })
+      magic.requestUserDeletion.mockResolvedValue({ processed: [address], unprocessed: [] })
+    })
+
+    it('should request the deletion from Magic with the recovered address', async () => {
+      await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+
+      expect(magic.requestUserDeletion).toHaveBeenCalledWith(address)
+    })
+
+    it('should purge local data for the address', async () => {
+      await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+
+      expect(onboarding.deleteByWallet).toHaveBeenCalledWith(address)
+    })
+
+    it('should resolve with the address and the Magic result', async () => {
+      const result = await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+
+      expect(result).toEqual({ address, magic: { processed: [address], unprocessed: [] } })
+    })
+  })
+
+  describe('and the DID token address does not match the signer', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({
+        address: '0x1111111111111111111111111111111111111111',
+        issuer: 'did:ethr:0x1111111111111111111111111111111111111111',
+        iat: nowSeconds,
+        tid
+      })
+    })
+
+    it('should throw an AddressMismatchError', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(AddressMismatchError)
+    })
+
+    it('should not request the deletion from Magic', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(AddressMismatchError)
+
+      expect(magic.requestUserDeletion).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the DID token is stale', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds - 1000, tid })
+    })
+
+    it('should throw a DidTokenStaleError', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(DidTokenStaleError)
+    })
+
+    it('should not request the deletion from Magic', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(DidTokenStaleError)
+
+      expect(magic.requestUserDeletion).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the DID token has already been used', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds, tid })
+      magic.requestUserDeletion.mockResolvedValue({ processed: [address], unprocessed: [] })
+    })
+
+    it('should throw a DidTokenReusedError on the second attempt', async () => {
+      await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(DidTokenReusedError)
+    })
+
+    it('should request the deletion from Magic only once', async () => {
+      await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(DidTokenReusedError)
+
+      expect(magic.requestUserDeletion).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and the Magic deletion fails', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds, tid })
+      magic.requestUserDeletion.mockRejectedValue(new MagicRateLimitError())
+    })
+
+    it('should propagate the Magic error', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(MagicRateLimitError)
+    })
+
+    it('should not purge local data', async () => {
+      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(MagicRateLimitError)
+
+      expect(onboarding.deleteByWallet).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the local purge fails after the Magic deletion succeeds', () => {
+    beforeEach(() => {
+      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds, tid })
+      magic.requestUserDeletion.mockResolvedValue({ processed: [address], unprocessed: [] })
+      onboarding.deleteByWallet.mockRejectedValue(new Error('db down'))
+    })
+
+    it('should still resolve successfully', async () => {
+      const result = await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
+
+      expect(result).toEqual({ address, magic: { processed: [address], unprocessed: [] } })
+    })
+  })
+})

--- a/test/unit/account-deletion.spec.ts
+++ b/test/unit/account-deletion.spec.ts
@@ -4,7 +4,6 @@ import { IMagicAdapter, MagicRateLimitError } from '../../src/adapters/magic'
 import { createAccountDeletionComponent } from '../../src/logic/account-deletion/component'
 import { AddressMismatchError, DidTokenReusedError, DidTokenStaleError } from '../../src/logic/account-deletion/errors'
 import { IAccountDeletionComponent } from '../../src/logic/account-deletion/types'
-import { IOnboardingComponent } from '../../src/ports/onboarding/types'
 import { createStorageComponent } from '../../src/ports/storage/component'
 import { IStorageComponent } from '../../src/ports/storage/types'
 
@@ -16,7 +15,6 @@ function createMockLogs(): ILoggerComponent {
 describe('when deleting an account', () => {
   let accountDeletion: IAccountDeletionComponent
   let magic: jest.Mocked<Pick<IMagicAdapter, 'validateDidToken' | 'requestUserDeletion'>>
-  let onboarding: jest.Mocked<Pick<IOnboardingComponent, 'deleteByWallet'>>
   let storage: IStorageComponent
   let address: string
   let signedFetchAddress: string
@@ -36,13 +34,11 @@ describe('when deleting an account', () => {
       validateDidToken: jest.fn(),
       requestUserDeletion: jest.fn()
     }
-    onboarding = { deleteByWallet: jest.fn().mockResolvedValue(undefined) }
     storage = createStorageComponent({ cache: createInMemoryCacheComponent() })
 
     accountDeletion = createAccountDeletionComponent({
       magic: magic as unknown as IMagicAdapter,
       storage,
-      onboarding: onboarding as unknown as IOnboardingComponent,
       logs: createMockLogs(),
       didTokenMaxAgeSeconds: 120
     })
@@ -58,12 +54,6 @@ describe('when deleting an account', () => {
       await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
 
       expect(magic.requestUserDeletion).toHaveBeenCalledWith(address)
-    })
-
-    it('should purge local data for the address', async () => {
-      await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
-
-      expect(onboarding.deleteByWallet).toHaveBeenCalledWith(address)
     })
 
     it('should resolve with the address and the Magic result', async () => {
@@ -138,26 +128,6 @@ describe('when deleting an account', () => {
 
     it('should propagate the Magic error', async () => {
       await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(MagicRateLimitError)
-    })
-
-    it('should not purge local data', async () => {
-      await expect(accountDeletion.deleteAccount({ signedFetchAddress, didToken })).rejects.toThrow(MagicRateLimitError)
-
-      expect(onboarding.deleteByWallet).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('and the local purge fails after the Magic deletion succeeds', () => {
-    beforeEach(() => {
-      magic.validateDidToken.mockReturnValue({ address, issuer: `did:ethr:${address}`, iat: nowSeconds, tid })
-      magic.requestUserDeletion.mockResolvedValue({ processed: [address], unprocessed: [] })
-      onboarding.deleteByWallet.mockRejectedValue(new Error('db down'))
-    })
-
-    it('should still resolve successfully', async () => {
-      const result = await accountDeletion.deleteAccount({ signedFetchAddress, didToken })
-
-      expect(result).toEqual({ address, magic: { processed: [address], unprocessed: [] } })
     })
   })
 })

--- a/test/unit/magic-adapter.spec.ts
+++ b/test/unit/magic-adapter.spec.ts
@@ -1,0 +1,213 @@
+import { Magic, SDKError, ErrorCode } from '@magic-sdk/admin'
+import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { createMagicAdapter } from '../../src/adapters/magic/component'
+import {
+  MagicAuthError,
+  MagicDeletionError,
+  MagicRateLimitError,
+  MagicTokenExpiredError,
+  MagicTokenInvalidError
+} from '../../src/adapters/magic/errors'
+import { IMagicAdapter } from '../../src/adapters/magic/types'
+
+// Mock only the Magic class — keep the real SDKError / ErrorCode so `instanceof`
+// checks and enum comparisons in the adapter work against real values.
+jest.mock('@magic-sdk/admin', () => {
+  const actual = jest.requireActual('@magic-sdk/admin')
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Magic: jest.fn()
+  }
+})
+
+function createMockLogs(): ILoggerComponent {
+  const logger = { log: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() }
+  return { getLogger: () => logger } as unknown as ILoggerComponent
+}
+
+function createMockConfig(overrides: Record<string, string | undefined> = {}): IConfigComponent {
+  const defaults: Record<string, string | undefined> = {
+    MAGIC_SECRET_KEY: 'sk_test_dummy_key',
+    MAGIC_API_URL: 'https://api.magic.link',
+    MAGIC_CLIENT_ID: undefined
+  }
+  const values = { ...defaults, ...overrides }
+
+  return {
+    requireString: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key])),
+    getString: jest.fn().mockImplementation((key: string) => Promise.resolve(values[key] ?? undefined)),
+    requireNumber: jest.fn(),
+    getNumber: jest.fn()
+  } as unknown as IConfigComponent
+}
+
+describe('when using the Magic adapter', () => {
+  let adapter: IMagicAdapter
+  let fetchMock: jest.Mock
+  let tokenValidate: jest.Mock
+  let tokenDecode: jest.Mock
+  let tokenGetPublicAddress: jest.Mock
+  let secretKey: string
+
+  beforeEach(async () => {
+    secretKey = 'sk_test_dummy_key'
+    tokenValidate = jest.fn()
+    tokenDecode = jest.fn()
+    tokenGetPublicAddress = jest.fn()
+    ;(Magic as unknown as jest.Mock).mockImplementation(() => ({
+      token: { validate: tokenValidate, decode: tokenDecode, getPublicAddress: tokenGetPublicAddress }
+    }))
+    fetchMock = jest.fn()
+
+    adapter = await createMagicAdapter({
+      config: createMockConfig({ MAGIC_SECRET_KEY: secretKey }),
+      logs: createMockLogs(),
+      fetch: { fetch: fetchMock } as unknown as IFetchComponent
+    })
+  })
+
+  describe('and validating a DID token', () => {
+    describe('and the token is valid', () => {
+      let claim: { iat: number; ext: number; iss: string; sub: string; aud: string; nbf: number; tid: string; add: string }
+
+      beforeEach(() => {
+        claim = {
+          iat: 1700000000,
+          ext: 1700000900,
+          iss: 'did:ethr:0xAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbC0',
+          sub: 'sub',
+          aud: 'aud',
+          nbf: 1700000000,
+          tid: 'tid-123',
+          add: 'none'
+        }
+        tokenValidate.mockReturnValue(undefined)
+        tokenDecode.mockReturnValue(['proof', claim])
+        tokenGetPublicAddress.mockReturnValue('0xAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbCAbC0')
+      })
+
+      it('should return the lowercased address, issuer, iat and tid', () => {
+        expect(adapter.validateDidToken('valid-token')).toEqual({
+          address: '0xabcabcabcabcabcabcabcabcabcabcabcabcabc0',
+          issuer: claim.iss,
+          iat: claim.iat,
+          tid: claim.tid
+        })
+      })
+    })
+
+    describe('and the token is expired', () => {
+      beforeEach(() => {
+        tokenValidate.mockImplementation(() => {
+          throw new SDKError(ErrorCode.TokenExpired, 'expired')
+        })
+      })
+
+      it('should throw a MagicTokenExpiredError', () => {
+        expect(() => adapter.validateDidToken('expired-token')).toThrow(MagicTokenExpiredError)
+      })
+    })
+
+    describe('and the token cannot be used yet', () => {
+      beforeEach(() => {
+        tokenValidate.mockImplementation(() => {
+          throw new SDKError(ErrorCode.TokenCannotBeUsedYet, 'nbf')
+        })
+      })
+
+      it('should throw a MagicTokenExpiredError', () => {
+        expect(() => adapter.validateDidToken('nbf-token')).toThrow(MagicTokenExpiredError)
+      })
+    })
+
+    describe('and the signature cannot be recovered', () => {
+      beforeEach(() => {
+        tokenValidate.mockImplementation(() => {
+          throw new SDKError(ErrorCode.FailedRecoveryProof, 'bad signature')
+        })
+      })
+
+      it('should throw a MagicTokenInvalidError', () => {
+        expect(() => adapter.validateDidToken('bad-token')).toThrow(MagicTokenInvalidError)
+      })
+    })
+
+    describe('and a non-SDK error is thrown', () => {
+      beforeEach(() => {
+        tokenValidate.mockImplementation(() => {
+          throw new Error('unexpected')
+        })
+      })
+
+      it('should throw a MagicTokenInvalidError', () => {
+        expect(() => adapter.validateDidToken('weird-token')).toThrow(MagicTokenInvalidError)
+      })
+    })
+  })
+
+  describe('and requesting user deletion', () => {
+    let address: string
+
+    beforeEach(() => {
+      address = '0xabcabcabcabcabcabcabcabcabcabcabcabcabc0'
+    })
+
+    describe('and Magic responds with 200', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ processed: [address], unprocessed: [] })
+        })
+      })
+
+      it('should return the processed and unprocessed lists', async () => {
+        await expect(adapter.requestUserDeletion(address)).resolves.toEqual({ processed: [address], unprocessed: [] })
+      })
+
+      it('should call Magic with the secret key header and the public_addresses body', async () => {
+        await adapter.requestUserDeletion(address)
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.magic.link/v1/admin/user/deletion/request',
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({ 'X-Magic-Secret-Key': secretKey, 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ public_addresses: [address] })
+          })
+        )
+      })
+    })
+
+    describe('and Magic responds with 401', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValue({ ok: false, status: 401 })
+      })
+
+      it('should throw a MagicAuthError', async () => {
+        await expect(adapter.requestUserDeletion(address)).rejects.toThrow(MagicAuthError)
+      })
+    })
+
+    describe('and Magic responds with 429', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValue({ ok: false, status: 429 })
+      })
+
+      it('should throw a MagicRateLimitError', async () => {
+        await expect(adapter.requestUserDeletion(address)).rejects.toThrow(MagicRateLimitError)
+      })
+    })
+
+    describe('and Magic responds with an unexpected error', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => 'boom' })
+      })
+
+      it('should throw a MagicDeletionError', async () => {
+        await expect(adapter.requestUserDeletion(address)).rejects.toThrow(MagicDeletionError)
+      })
+    })
+  })
+})

--- a/test/unit/magic-adapter.spec.ts
+++ b/test/unit/magic-adapter.spec.ts
@@ -30,7 +30,7 @@ function createMockConfig(overrides: Record<string, string | undefined> = {}): I
   const defaults: Record<string, string | undefined> = {
     MAGIC_SECRET_KEY: 'sk_test_dummy_key',
     MAGIC_API_URL: 'https://api.magic.link',
-    MAGIC_CLIENT_ID: undefined
+    MAGIC_CLIENT_ID: 'test-client-id'
   }
   const values = { ...defaults, ...overrides }
 

--- a/test/utils/signed-request.ts
+++ b/test/utils/signed-request.ts
@@ -7,10 +7,11 @@ export type SignedRequestOptions = {
   body?: unknown
   identity?: AuthIdentity
   headers?: Record<string, string>
+  metadata?: Record<string, unknown>
 }
 
 export async function createSignedFetchRequest(baseUrl: string, options: SignedRequestOptions) {
-  const { method, path, body, identity, headers } = options
+  const { method, path, body, identity, headers, metadata } = options
   const response = await fetch(baseUrl + path, {
     method,
     headers: {
@@ -18,7 +19,8 @@ export async function createSignedFetchRequest(baseUrl: string, options: SignedR
       ...headers
     },
     body: JSON.stringify(body),
-    identity: identity
+    identity: identity,
+    metadata: metadata
   })
 
   return response


### PR DESCRIPTION
## Why

Users who created their wallet through **Magic** (`magic-sdk` / Magic Lab) need a way to permanently delete their Magic account. Magic exposes a GDPR deletion endpoint authenticated with the app **secret key**. Because deletion is **irreversible**, the core requirement is proving the request was made deliberately by the real user and **cannot be triggered or relayed by a phishing/clone site on a different origin**.

Two constraints shaped the design:
- Wallet signatures are no longer shown to users, so a signature is **authentication, not consent**.
- Not every Magic account has an email (SMS / passkey / some OAuth), so deletion targets the **public address**.

## How

New **`DELETE /accounts`** endpoint with two layered, cross-checked credentials:

1. **Magic DID token** — minted fresh on the official page, validated server-side with the Magic secret key via `@magic-sdk/admin` (signature, expiry, optional `aud`). Unobtainable off-domain (the Magic publishable key is domain-locked), must be recent (`iat` freshness), and single-use (`tid`). It is carried in the **signed-fetch metadata** (`x-identity-metadata`), so it is covered by the request signature (`method:path:timestamp:metadata`) — no request body.
2. **DCL signed-fetch** — recovers `req.auth`, which **must equal** the DID-token address.

Plus defense-in-depth: an **Origin/Referer allowlist** (CORS + explicit server-side check) against browser cross-origin calls. On success the server calls Magic's deletion endpoint by `public_addresses`. Typed errors map to `400/401/403/429/500`.

It intentionally does **not** delete local onboarding/nudge data: removing the Magic account only revokes Magic's custodial access and does **not** delete the wallet itself (the user can export the key beforehand), so the address can remain an active Decentraland identity.

New code follows the WKC layout:
- `src/adapters/magic` — DID-token validation + Magic deletion API call.
- `src/logic/account-deletion` — orchestration (validate → cross-check → freshness → one-time → delete → audit).

## Config

| Var | Notes |
|-----|-------|
| `MAGIC_SECRET_KEY` | Required, **secret** — provision via the deploy secret store |
| `MAGIC_API_URL` | Default `https://api.magic.link` |
| `MAGIC_CLIENT_ID` | Optional — enables the DID-token audience check |
| `MAGIC_DID_TOKEN_MAX_AGE_SECONDS` | Default `120` |
| `ACCOUNT_DELETION_ALLOWED_ORIGINS` | Semicolon-separated; empty disables the origin check |

## Testing

- **Unit** — Magic adapter (token validation + error mapping; deletion HTTP status mapping) and account-deletion logic (address cross-check, freshness, replay).
- **Integration** — real signed-fetch happy path, replay → 403, address mismatch → 403, invalid token → 401, disallowed origin → 403, not-signed → 400, missing token → 400.
- `npm test` (153 passing), `npm run test:integration` (87 passing), lint, prettier, and build all green.

## Operational prerequisites

- Provision **`MAGIC_SECRET_KEY`** to the deploy secret store.
- Ensure the Magic **publishable key's Allowed-Origins** is locked to `decentraland.org` — this is what makes the DID token unobtainable from a different server.

## Notes

- The `didToken` is sent in the **signed-fetch metadata** (`x-identity-metadata` header), so it is bound to the request signature and the endpoint needs no request body.
- Frontend work (confirm UI, minting the short-lived DID token, passing it as signed-fetch metadata) lives in the client repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
