### PR TITLE
fix: persist requiresValidation so it survives storage reads

### DIFF
--- a/src/controllers/handlers/requests.ts
+++ b/src/controllers/handlers/requests.ts
@@ -158,7 +158,10 @@ export async function notifyRequestValidationHandler(
     socketServer.emitToSocket(request.socketId, MessageType.REQUEST_VALIDATION_STATUS, { requestId })
   }
 
+  // Persist the flag: storage.getRequest returns a copy, so mutating `request` alone would be lost
+  // (and GET /v2/requests/:id/validation would always report false).
   request.requiresValidation = true
+  await storage.setRequest(requestId, request)
 
   return { status: 204, body: undefined }
 }

--- a/src/logic/socket-server/handlers/request-validation.ts
+++ b/src/logic/socket-server/handlers/request-validation.ts
@@ -43,7 +43,9 @@ export async function requestValidationSocketHandler(context: SocketHandlerConte
     emitToSocket(request.socketId, MessageType.REQUEST_VALIDATION_STATUS, { requestId: msg.requestId, code: request.code })
   }
 
+  // Persist the flag: storage.getRequest returns a copy, so mutating `request` alone would be lost.
   request.requiresValidation = true
+  await storage.setRequest(msg.requestId, request)
 
   return {}
 }

--- a/test/integration/with-polling.spec.ts
+++ b/test/integration/with-polling.spec.ts
@@ -450,48 +450,46 @@ test('when posting that a request needs validation and the request is valid', ar
 //   }
 // )
 
-// test('when getting the request validation status of a request that should not be validated', args => {
-//   let requestResponse: RequestResponseMessage
+test('when getting the request validation status of a request that should not be validated', args => {
+  let requestResponse: RequestResponseMessage
 
-//   beforeEach(async () => {
-//     const port = await args.components.config.requireString('HTTP_SERVER_PORT')
-//     httpClient = await createHttpClient(port)
-//     requestResponse = (await httpClient.request({
-//       method: METHOD_DCL_PERSONAL_SIGN,
-//       params: []
-//     })) as RequestResponseMessage
-//   })
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
+    requestResponse = (await httpClient.request({
+      method: METHOD_DCL_PERSONAL_SIGN,
+      params: []
+    })) as RequestResponseMessage
+  })
 
-//   it('should respond with a 200 and the request validation status as false', async () => {
-//     const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
+  it('should respond with a 200 and the request validation status as false', async () => {
+    const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
 
-//     expect(response).toEqual({
-//       requestId: requestResponse.requestId,
-//       requiresValidation: false
-//     })
-//   })
-// })
+    expect(response).toEqual({
+      requiresValidation: false
+    })
+  })
+})
 
-// test('when getting the request validation status of a request that should be validated', args => {
-//   let requestResponse: RequestResponseMessage
+test('when getting the request validation status of a request that should be validated', args => {
+  let requestResponse: RequestResponseMessage
 
-//   beforeEach(async () => {
-//     const port = await args.components.config.requireString('HTTP_SERVER_PORT')
-//     httpClient = await createHttpClient(port)
-//     requestResponse = (await httpClient.request({
-//       method: METHOD_DCL_PERSONAL_SIGN,
-//       params: []
-//     })) as RequestResponseMessage
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    httpClient = await createHttpClient(port)
+    requestResponse = (await httpClient.request({
+      method: METHOD_DCL_PERSONAL_SIGN,
+      params: []
+    })) as RequestResponseMessage
 
-//     await httpClient.notifyRequestValidation(requestResponse.requestId)
-//   })
+    await httpClient.notifyRequestValidation(requestResponse.requestId)
+  })
 
-//   it('should respond with a 200 and the request validation status as true', async () => {
-//     const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
+  it('should respond with a 200 and the request validation status as true', async () => {
+    const response = await httpClient.getRequestValidationStatus(requestResponse.requestId)
 
-//     expect(response).toEqual({
-//       requestId: requestResponse.requestId,
-//       requiresValidation: true
-//     })
-//   })
-// })
+    expect(response).toEqual({
+      requiresValidation: true
+    })
+  })
+})


### PR DESCRIPTION
Follow-up to the review of #135 (comment #2).

## Bug
`storage.getRequest` returns a fresh copy (`{ ...raw, expiration: toDate(raw.expiration) }`), so `request.requiresValidation = true` was mutating a throwaway object in **both**:
- the socket `request-validation` handler, and
- the HTTP `notifyRequestValidationHandler` (`requests.ts`).

The flag was never persisted, so `GET /v2/requests/:id/validation` **always returned `false`** — the whole "request requires validation" mechanism was broken. (This is why the two validation-status tests in `with-polling.spec.ts` were commented out.)

## Fix
Persist the flag via `storage.setRequest(requestId, request)` after setting it, in both handlers.

## Test
Re-enables the two `request-validation-status` tests in `with-polling.spec.ts`, correcting their stale expected shape (`{ requiresValidation }` — the response no longer carries `requestId`). The **"should be validated"** case is the regression: `notify → GET → requiresValidation: true`, which only passes when the flag is persisted.

## Verification
- build + lint clean
- **161 unit + 90 integration** (the 2 re-enabled tests)

> **Stacked on #135** (base is `refactor/socket-message-handlers`), since the socket handler was refactored there. Once #135 merges this will retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)