### PR TITLE
fix: harden IP/code/CORS handling and dedup request-lifecycle guards

### DIFF
--- a/src/controllers/handlers/requests.ts
+++ b/src/controllers/handlers/requests.ts
@@ -1,6 +1,8 @@
+import { randomInt } from 'crypto'
 import { v4 as uuid } from 'uuid'
 import { validateAuthChain } from '../../logic/auth-chain'
 import { isErrorWithMessage } from '../../logic/error-handling'
+import { loadActiveRequest, logInboundRequestStateError, RequestStateError, requestStateErrorToHttpResponse } from '../../logic/requests'
 import { METHOD_DCL_PERSONAL_SIGN } from '../../ports/server/constants'
 import {
   HttpOutcomeMessage,
@@ -13,6 +15,7 @@ import {
   RequestValidationStatusMessage
 } from '../../ports/server/types'
 import { validateHttpOutcomeMessage, validateRequestMessage } from '../../ports/server/validations'
+import { StorageRequest } from '../../ports/storage/types'
 import { HandlerContextWithPath } from '../../types'
 import { parseJsonBody } from '../utils'
 
@@ -60,7 +63,8 @@ export function createRequestHandler({ requestExpirationInSeconds, dclPersonalSi
     const expiration = new Date(
       Date.now() + (msg.method !== METHOD_DCL_PERSONAL_SIGN ? requestExpirationInSeconds : dclPersonalSignExpirationInSeconds) * 1000
     )
-    const code = Math.floor(Math.random() * 100)
+    // Cryptographically secure so the pairing code the user visually confirms can't be predicted.
+    const code = randomInt(0, 100)
 
     await storage.setRequest(requestId, {
       requestId: requestId,
@@ -86,23 +90,14 @@ export async function getRequestHandler(context: HandlerContextWithPath<Requests
     components: { storage }
   } = context
 
-  const request = await storage.getRequest(requestId)
-
-  if (!request) {
-    return { status: 404, body: { error: `Request with id "${requestId}" not found` } satisfies InvalidResponseMessage }
-  }
-
-  if (request.fulfilled) {
-    return {
-      status: 410,
-      body: { error: `Request with id "${requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      return requestStateErrorToHttpResponse(e)
     }
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(requestId, null)
-
-    return { status: 410, body: { error: `Request with id "${requestId}" has expired` } satisfies InvalidResponseMessage }
+    throw e
   }
 
   return {
@@ -128,28 +123,15 @@ export async function notifyRequestValidationHandler(
 
   const logger = logs.getLogger('websocket-server')
 
-  const request = await storage.getRequest(requestId)
-
-  if (!request) {
-    logger.log(`[RID:${requestId}] Received a validation request message for a non-existent request`)
-    return { status: 404, body: { error: `Request with id "${requestId}" not found` } satisfies InvalidResponseMessage }
-  }
-
-  if (request.fulfilled) {
-    logger.log(`[RID:${requestId}] Received a validation request message for an already fulfilled request`)
-    return {
-      status: 410,
-      body: { error: `Request with id "${requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      logInboundRequestStateError(logger, requestId, 'a validation request message', e)
+      return requestStateErrorToHttpResponse(e)
     }
-  }
-
-  if (request.expiration < new Date()) {
-    logger.log(`[RID:${requestId}] Received a validation request message for an expired request`)
-
-    // Remove the request from the storage as it is expired
-    await storage.setRequest(requestId, null)
-
-    return { status: 410, body: { error: `Request with id "${requestId}" has expired` } satisfies InvalidResponseMessage }
+    throw e
   }
 
   if (request.socketId && socketServer.isSocketConnected(request.socketId) && !request.requiresValidation) {
@@ -175,23 +157,14 @@ export async function getRequestValidationStatusHandler(
     components: { storage }
   } = context
 
-  const request = await storage.getRequest(requestId)
-
-  if (!request) {
-    return { status: 404, body: { error: `Request with id "${requestId}" not found` } satisfies InvalidResponseMessage }
-  }
-
-  if (request.fulfilled) {
-    return {
-      status: 410,
-      body: { error: `Request with id "${requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      return requestStateErrorToHttpResponse(e)
     }
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(requestId, null)
-
-    return { status: 410, body: { error: `Request with id "${requestId}" has expired` } satisfies InvalidResponseMessage }
+    throw e
   }
 
   return {
@@ -209,29 +182,19 @@ export async function getOutcomeHandler(context: HandlerContextWithPath<Requests
 
   const logger = logs.getLogger('websocket-server')
 
-  const request = await storage.getRequest(requestId)
-
-  if (!request) {
-    return { status: 404, body: { error: `Request with id "${requestId}" not found` } satisfies InvalidResponseMessage }
-  }
-
-  if (request.fulfilled) {
-    return {
-      status: 410,
-      body: { error: `Request with id "${requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      return requestStateErrorToHttpResponse(e)
     }
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(requestId, null)
-    return { status: 410, body: { error: `Request with id "${requestId}" has expired` } satisfies InvalidResponseMessage }
+    throw e
   }
 
   if (!request.response) {
-    return {
-      status: 204,
-      body: { error: `Request with id "${requestId}" has not been completed` } satisfies InvalidResponseMessage
-    }
+    // Not completed yet — 204 No Content (no body, per the HTTP spec) so the client keeps polling.
+    return { status: 204, body: undefined }
   }
 
   logger.log(`[RID:${requestId}] Successfully sent outcome message to the client via HTTP`)
@@ -271,35 +234,15 @@ export async function createOutcomeHandler(context: HandlerContextWithPath<Reque
     }
   }
 
-  const request = await storage.getRequest(requestId)
-
-  if (!request) {
-    logger.log(`[RID:${requestId}] Received an outcome message for a non-existent request`)
-    return { status: 404, body: { error: `Request with id "${requestId}" not found` } satisfies InvalidResponseMessage }
-  }
-
-  if (request.fulfilled) {
-    logger.log(`[RID:${requestId}] Received an outcome message for an already fulfilled request`)
-    return {
-      status: 410,
-      body: { error: `Request with id "${requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, requestId, { rejectIfHasResponse: true })
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      logInboundRequestStateError(logger, requestId, 'an outcome message', e)
+      return requestStateErrorToHttpResponse(e)
     }
-  }
-
-  if (request.response) {
-    logger.log(`[RID:${requestId}] Received an outcome message for a request that already has a response`)
-
-    return {
-      status: 400,
-      body: { error: `Request with id "${requestId}" already has a response` } satisfies InvalidResponseMessage
-    }
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(requestId, null)
-
-    logger.log(`[RID:${requestId}] Received an outcome message for an expired request`)
-    return { status: 410, body: { error: `Request with id "${requestId}" has expired` } satisfies InvalidResponseMessage }
+    throw e
   }
 
   const outcomeMessage: OutcomeResponseMessage = {

--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -34,25 +34,41 @@ export function normalizeIp(ip: string): string {
 
 /**
  * Gets the client IP address from request headers.
- * Prioritizes trusted headers (True-Client-IP, X-Real-IP, Cloudflare's CF-Connecting-IP) over X-Forwarded-For.
+ *
+ * Header priority reflects trustworthiness at our edge (Cloudflare). The headers are
+ * consulted most-trusted first because the identity IP-binding check relies on this
+ * value:
+ *
+ * 1. `CF-Connecting-IP` — set by Cloudflare on every proxied request and overwritten
+ *    if the client tries to forge it; the only header a direct client cannot spoof
+ *    through the edge.
+ * 2. `True-Client-IP` / `X-Real-IP` — also set by proxies, but only on some plans /
+ *    configurations, and NOT guaranteed to be stripped from inbound requests. They are
+ *    lower priority so a forged value cannot override the genuine `CF-Connecting-IP`.
+ * 3. `X-Forwarded-For` — a client-appendable list; only the first entry is taken.
+ * 4. The Node socket remote address (stamped onto a header by `main()`).
+ *
+ * NOTE: the edge MUST strip inbound `True-Client-IP`/`X-Real-IP`/`X-Forwarded-For` from
+ * untrusted clients for the lower-priority headers to be meaningful; the ordering here
+ * only guarantees Cloudflare's value wins when present.
  */
 export function getClientIp(headers: Headers): string {
-  // Check True-Client-IP header (set by proxies like Cloudflare, contains the visitor's IP address)
+  // Cloudflare's trusted header — set/overwritten by the edge, cannot be spoofed through it.
+  const cfConnectingIp = headers.get('cf-connecting-ip')
+  if (cfConnectingIp) {
+    return normalizeIp(cfConnectingIp)
+  }
+
+  // True-Client-IP (set by some proxy plans, e.g. Cloudflare Enterprise).
   const trueClientIp = headers.get('true-client-ip')
   if (trueClientIp) {
     return normalizeIp(trueClientIp)
   }
 
-  // Check X-Real-IP header (set by proxies when configured, more trustworthy than X-Forwarded-For)
+  // X-Real-IP (set by proxies when configured, more trustworthy than X-Forwarded-For).
   const xRealIp = headers.get('x-real-ip')
   if (xRealIp) {
     return normalizeIp(xRealIp)
-  }
-
-  // Check CF-Connecting-IP header first (Cloudflare's trusted header, cannot be spoofed)
-  const cfConnectingIp = headers.get('cf-connecting-ip')
-  if (cfConnectingIp) {
-    return normalizeIp(cfConnectingIp)
   }
 
   // Check X-Forwarded-For header (can be spoofed, use with caution)

--- a/src/logic/cors.ts
+++ b/src/logic/cors.ts
@@ -6,12 +6,14 @@
  * regex such as `https://foo\.org` is a substring match, which would let `https://foo.org.evil.com`
  * pass the CORS check. A leading `^` / trailing `$` the operator already supplied is stripped first
  * so we don't double-anchor, and empty entries (e.g. a trailing `;`) are dropped instead of turning
- * into an allow-all regex.
+ * into an allow-all regex. The entry is wrapped in a non-capturing group so a top-level alternation
+ * (`a|b`) stays fully anchored — `^a|b$` would otherwise parse as `(^a)|(b$)`, leaving each side
+ * only half-anchored and re-opening the substring-bypass hole.
  */
 export function parseCorsOrigins(corsOrigin: string): RegExp[] {
   return corsOrigin
     .split(';')
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0)
-    .map(entry => new RegExp(`^${entry.replace(/^\^/, '').replace(/\$$/, '')}$`))
+    .map(entry => new RegExp(`^(?:${entry.replace(/^\^/, '').replace(/\$$/, '')})$`))
 }

--- a/src/logic/error-handling.ts
+++ b/src/logic/error-handling.ts
@@ -1,3 +1,9 @@
 export function isErrorWithMessage(error: unknown): error is Error {
-  return error !== undefined && error !== null && typeof error === 'object' && 'message' in error
+  return (
+    error !== undefined &&
+    error !== null &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  )
 }

--- a/src/logic/error-handling.ts
+++ b/src/logic/error-handling.ts
@@ -1,4 +1,4 @@
-export function isErrorWithMessage(error: unknown): error is Error {
+export function isErrorWithMessage(error: unknown): error is { message: string } {
   return (
     error !== undefined &&
     error !== null &&

--- a/src/logic/requests/errors.ts
+++ b/src/logic/requests/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Base class for the request-lifecycle guard failures shared by the HTTP and socket
+ * handlers. Carries the offending `requestId` so callers can log with an `[RID:…]` prefix,
+ * and lets handlers detect an expected guard failure (`instanceof RequestStateError`) from
+ * an unexpected throw that should propagate to the error middleware / Sentry.
+ */
+export abstract class RequestStateError extends Error {
+  constructor(message: string, public readonly requestId: string) {
+    super(message)
+    this.name = new.target.name
+  }
+}
+
+/** No request exists for the id. Maps to HTTP 404. */
+export class RequestNotFoundError extends RequestStateError {
+  constructor(requestId: string) {
+    super(`Request with id "${requestId}" not found`, requestId)
+  }
+}
+
+/** The request was already consumed (its outcome was delivered). Maps to HTTP 410. */
+export class RequestAlreadyFulfilledError extends RequestStateError {
+  constructor(requestId: string) {
+    super(`Request with id "${requestId}" has already been fulfilled`, requestId)
+  }
+}
+
+/** An outcome was already stored for this request. Maps to HTTP 400. */
+export class RequestAlreadyHasResponseError extends RequestStateError {
+  constructor(requestId: string) {
+    super(`Request with id "${requestId}" already has a response`, requestId)
+  }
+}
+
+/** The request's expiration has passed. Maps to HTTP 410. */
+export class RequestExpiredError extends RequestStateError {
+  constructor(requestId: string) {
+    super(`Request with id "${requestId}" has expired`, requestId)
+  }
+}

--- a/src/logic/requests/index.ts
+++ b/src/logic/requests/index.ts
@@ -1,0 +1,100 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { InvalidResponseMessage } from '../../ports/server/types'
+import { IStorageComponent, StorageRequest } from '../../ports/storage/types'
+import {
+  RequestAlreadyFulfilledError,
+  RequestAlreadyHasResponseError,
+  RequestExpiredError,
+  RequestNotFoundError,
+  RequestStateError
+} from './errors'
+
+export * from './errors'
+
+export type LoadActiveRequestOptions = {
+  /**
+   * Reject the request when it already carries a stored response. Used by the outcome-submission
+   * paths (they must not overwrite an existing outcome); the polling read path leaves it off
+   * because it *requires* a response to be present.
+   */
+  rejectIfHasResponse?: boolean
+}
+
+/**
+ * Loads a request by id and asserts it is still actionable, applying the guards every
+ * request-lifecycle handler shares (HTTP and socket): not-found, already-fulfilled,
+ * optionally already-has-response, then expired. Guard order is significant and matches
+ * the previous per-handler code. On expiry the request is purged from storage (the side
+ * effect that was duplicated across every handler) before the error is thrown.
+ *
+ * Throws the typed errors in `./errors`; callers map them to an HTTP status
+ * (`requestStateErrorToHttpResponse`) or a socket error payload.
+ */
+export async function loadActiveRequest(
+  storage: Pick<IStorageComponent, 'getRequest' | 'setRequest'>,
+  requestId: string,
+  options: LoadActiveRequestOptions = {}
+): Promise<StorageRequest> {
+  const request = await storage.getRequest(requestId)
+
+  if (!request) {
+    throw new RequestNotFoundError(requestId)
+  }
+
+  if (request.fulfilled) {
+    throw new RequestAlreadyFulfilledError(requestId)
+  }
+
+  if (options.rejectIfHasResponse && request.response) {
+    throw new RequestAlreadyHasResponseError(requestId)
+  }
+
+  if (request.expiration < new Date()) {
+    await storage.setRequest(requestId, null)
+    throw new RequestExpiredError(requestId)
+  }
+
+  return request
+}
+
+/** Maps a request-lifecycle guard failure to its HTTP status and response body. */
+export function requestStateErrorToHttpResponse(error: RequestStateError): {
+  status: number
+  body: InvalidResponseMessage
+} {
+  const body = { error: error.message } satisfies InvalidResponseMessage
+
+  if (error instanceof RequestNotFoundError) {
+    return { status: 404, body }
+  }
+
+  if (error instanceof RequestAlreadyHasResponseError) {
+    return { status: 400, body }
+  }
+
+  // RequestAlreadyFulfilledError and RequestExpiredError both signal a request that existed but is
+  // no longer actionable.
+  return { status: 410, body }
+}
+
+/**
+ * Logs a guard failure for an inbound message about an existing request, preserving the
+ * `[RID:…] Received <subject> for a <state> request` wording the handlers used. `subject`
+ * is the per-handler noun phrase, e.g. `'an outcome message'` or `'a recover request'`.
+ */
+export function logInboundRequestStateError(
+  logger: ILoggerComponent.ILogger,
+  requestId: string,
+  subject: string,
+  error: RequestStateError
+): void {
+  if (error instanceof RequestNotFoundError) {
+    logger.log(`[RID:${requestId}] Received ${subject} for a non-existent request`)
+  } else if (error instanceof RequestAlreadyFulfilledError) {
+    logger.log(`[RID:${requestId}] Received ${subject} for an already fulfilled request`)
+  } else if (error instanceof RequestAlreadyHasResponseError) {
+    logger.log(`[RID:${requestId}] Received ${subject} for a request that already has a response`)
+  } else if (error instanceof RequestExpiredError) {
+    logger.log(`[RID:${requestId}] Received ${subject} for an expired request`)
+  }
+}

--- a/src/logic/requests/index.ts
+++ b/src/logic/requests/index.ts
@@ -96,5 +96,8 @@ export function logInboundRequestStateError(
     logger.log(`[RID:${requestId}] Received ${subject} for a request that already has a response`)
   } else if (error instanceof RequestExpiredError) {
     logger.log(`[RID:${requestId}] Received ${subject} for an expired request`)
+  } else {
+    // Defensive: a future RequestStateError subclass should still produce a log line.
+    logger.log(`[RID:${requestId}] Received ${subject} for a request in an unexpected state: ${error.message}`)
   }
 }

--- a/src/logic/socket-server/handlers/outcome.ts
+++ b/src/logic/socket-server/handlers/outcome.ts
@@ -1,6 +1,8 @@
 import { InvalidResponseMessage, MessageType, OutcomeMessage, OutcomeResponseMessage } from '../../../ports/server/types'
 import { validateOutcomeMessage } from '../../../ports/server/validations'
+import { StorageRequest } from '../../../ports/storage/types'
 import { isErrorWithMessage } from '../../error-handling'
+import { loadActiveRequest, logInboundRequestStateError, RequestStateError } from '../../requests'
 import { SocketHandlerContext } from '../types'
 
 // OUTCOME — records the outcome of a request and relays it to the waiting client, or persists it
@@ -21,27 +23,15 @@ export async function outcomeSocketHandler(context: SocketHandlerContext, data: 
     return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
   }
 
-  const request = await storage.getRequest(msg.requestId)
-
-  if (!request) {
-    logger.log(`[RID:${msg.requestId}] Received an outcome message for a non-existent request`)
-    return { error: `Request with id "${msg.requestId}" not found` } satisfies InvalidResponseMessage
-  }
-
-  if (request.fulfilled) {
-    logger.log(`[RID:${msg.requestId}] Received an outcome message for an already fulfilled request`)
-    return { error: `Request with id "${msg.requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
-  }
-
-  if (request.response) {
-    logger.log(`[RID:${msg.requestId}] Received an outcome message for a request that already has a response`)
-    return { error: `Request with id "${msg.requestId}" already has a response` } satisfies InvalidResponseMessage
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(msg.requestId, null)
-    logger.log(`[RID:${msg.requestId}] Received an outcome message for an expired request`)
-    return { error: `Request with id "${msg.requestId}" has expired` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, msg.requestId, { rejectIfHasResponse: true })
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      logInboundRequestStateError(logger, msg.requestId, 'an outcome message', e)
+      return { error: e.message } satisfies InvalidResponseMessage
+    }
+    throw e
   }
 
   const outcomeMessage: OutcomeResponseMessage = msg

--- a/src/logic/socket-server/handlers/recover.ts
+++ b/src/logic/socket-server/handlers/recover.ts
@@ -1,6 +1,8 @@
 import { InvalidResponseMessage, RecoverMessage, RecoverResponseMessage } from '../../../ports/server/types'
 import { validateRecoverMessage } from '../../../ports/server/validations'
+import { StorageRequest } from '../../../ports/storage/types'
 import { isErrorWithMessage } from '../../error-handling'
+import { loadActiveRequest, logInboundRequestStateError, RequestStateError } from '../../requests'
 import { SocketHandlerContext } from '../types'
 
 // RECOVER — returns a previously-registered, still-valid request by id.
@@ -20,22 +22,15 @@ export async function recoverSocketHandler(context: SocketHandlerContext, data: 
     return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
   }
 
-  const request = await storage.getRequest(msg.requestId)
-
-  if (!request) {
-    logger.log(`[RID:${msg.requestId}] Received a recover request for a non-existent request`)
-    return { error: `Request with id "${msg.requestId}" not found` } satisfies InvalidResponseMessage
-  }
-
-  if (request.fulfilled) {
-    logger.log(`[RID:${msg.requestId}] Received a recover request for an already fulfilled request`)
-    return { error: `Request with id "${msg.requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(msg.requestId, null)
-    logger.log(`[RID:${msg.requestId}] Received a recover request for an expired request`)
-    return { error: `Request with id "${msg.requestId}" has expired` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, msg.requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      logInboundRequestStateError(logger, msg.requestId, 'a recover request', e)
+      return { error: e.message } satisfies InvalidResponseMessage
+    }
+    throw e
   }
 
   logger.log(`[METHOD:${request.method}][RID:${request.requestId}][EXP:${request.expiration.getTime()}] Successfully recovered request`)

--- a/src/logic/socket-server/handlers/request-validation.ts
+++ b/src/logic/socket-server/handlers/request-validation.ts
@@ -1,6 +1,14 @@
 import { InvalidResponseMessage, MessageType, RequestValidationMessage } from '../../../ports/server/types'
 import { validateRequestValidationMessage } from '../../../ports/server/validations'
+import { StorageRequest } from '../../../ports/storage/types'
 import { isErrorWithMessage } from '../../error-handling'
+import {
+  loadActiveRequest,
+  RequestAlreadyFulfilledError,
+  RequestExpiredError,
+  RequestNotFoundError,
+  RequestStateError
+} from '../../requests'
 import { SocketHandlerContext } from '../types'
 
 // REQUEST_VALIDATION_STATUS — marks a request as requiring validation and notifies the waiting client.
@@ -20,22 +28,21 @@ export async function requestValidationSocketHandler(context: SocketHandlerConte
     return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
   }
 
-  const request = await storage.getRequest(msg.requestId)
-
-  if (!request) {
-    logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it doesn't exist`)
-    return { error: `Request with id "${msg.requestId}" not found` } satisfies InvalidResponseMessage
-  }
-
-  if (request.fulfilled) {
-    logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it has already been fulfilled`)
-    return { error: `Request with id "${msg.requestId}" has already been fulfilled` } satisfies InvalidResponseMessage
-  }
-
-  if (request.expiration < new Date()) {
-    await storage.setRequest(msg.requestId, null)
-    logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it has expired`)
-    return { error: `Request with id "${msg.requestId}" has expired` } satisfies InvalidResponseMessage
+  let request: StorageRequest
+  try {
+    request = await loadActiveRequest(storage, msg.requestId)
+  } catch (e) {
+    if (e instanceof RequestStateError) {
+      if (e instanceof RequestNotFoundError) {
+        logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it doesn't exist`)
+      } else if (e instanceof RequestAlreadyFulfilledError) {
+        logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it has already been fulfilled`)
+      } else if (e instanceof RequestExpiredError) {
+        logger.log(`[RID:${msg.requestId}] Tried to communicate that the request must be validated but it has expired`)
+      }
+      return { error: e.message } satisfies InvalidResponseMessage
+    }
+    throw e
   }
 
   if (request.socketId && isSocketConnected(request.socketId) && !request.requiresValidation) {

--- a/src/logic/socket-server/handlers/request.ts
+++ b/src/logic/socket-server/handlers/request.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'crypto'
 import { v4 as uuid } from 'uuid'
 import { METHOD_DCL_PERSONAL_SIGN } from '../../../ports/server/constants'
 import { InvalidResponseMessage, RequestMessage, RequestResponseMessage } from '../../../ports/server/types'
@@ -47,7 +48,8 @@ export function createRequestSocketHandler(options: SocketRequestExpirationOptio
       Date.now() +
         (msg.method !== METHOD_DCL_PERSONAL_SIGN ? options.requestExpirationInSeconds : options.dclPersonalSignExpirationInSeconds) * 1000
     )
-    const code = Math.floor(Math.random() * 100)
+    // Cryptographically secure so the pairing code the user visually confirms can't be predicted.
+    const code = randomInt(0, 100)
 
     await storage.setRequest(requestId, {
       requestId,

--- a/test/unit/cors.spec.ts
+++ b/test/unit/cors.spec.ts
@@ -37,6 +37,24 @@ describe('when parsing CORS origins', () => {
     })
   })
 
+  describe('and a single entry contains a top-level alternation', () => {
+    let origins: RegExp[]
+
+    beforeEach(() => {
+      origins = parseCorsOrigins('https://a\\.org|https://b\\.org')
+    })
+
+    it('should match each alternative exactly', () => {
+      expect(origins[0].test('https://a.org')).toBe(true)
+      expect(origins[0].test('https://b.org')).toBe(true)
+    })
+
+    it('should keep both alternatives anchored against suffix and prefix bypasses', () => {
+      expect(origins[0].test('https://a.org.evil.com')).toBe(false)
+      expect(origins[0].test('https://evil.com?x=https://b.org')).toBe(false)
+    })
+  })
+
   describe('and there are multiple semicolon-separated entries with empty ones', () => {
     let origins: RegExp[]
 


### PR DESCRIPTION
## Why

Findings from a bugs / security / improvements review of the request-lifecycle, identity, and CORS code paths. Each change is independent; grouped here because they came out of one pass.

## Security

- **`getClientIp` header trust ordering** (`src/controllers/utils.ts`) — Cloudflare's un-spoofable `cf-connecting-ip` is now consulted **before** the client-settable `true-client-ip` / `x-real-ip`. Previously a client could send `X-Real-IP: <victim-ip>` and override the genuine edge IP that the identity IP-binding check (`GET /identities/:id`) relies on. Added a doc note that the edge must still strip the lower-priority inbound headers.
- **Verification pairing code** (`controllers/handlers/requests.ts`, `logic/socket-server/handlers/request.ts`) — generated with `crypto.randomInt` instead of `Math.random()` so the code the user visually confirms isn't predictable. Range kept at 0–99 to stay compatible with the client display; widening it would need a coordinated frontend change.
- **CORS anchoring** (`logic/cors.ts`) — each entry is wrapped as `^(?:…)$` so a top-level alternation (`a|b`) stays fully anchored instead of degrading to `(^a)|(b$)`, which would reopen the substring-bypass hole the anchoring exists to close. Regression test added.

## Bug

- **204 with a body** (`getOutcomeHandler`) — the not-completed branch of `GET /requests/:requestId` returned a 204 carrying an error object. It now returns 204 with no body, per the HTTP spec, so clients keep polling correctly.

## Improvements

- **`isErrorWithMessage`** now requires `message` to be a string, so callers never interpolate a non-string message.
- **Shared request-lifecycle guard** — new `src/logic/requests/` module (typed errors + `loadActiveRequest` + HTTP mapper + log helper). The five HTTP request handlers and three socket handlers now route through it instead of each repeating the not-found → fulfilled → has-response → expired ladder and the easy-to-forget expire-on-read delete. **Response bodies, status codes, side effects, and log wording are preserved.**

## Not included (called out for follow-up)

- **DID-token replay protection race** (`consumeDidTokenId`) — a correct fix needs an atomic set-if-absent (`SET NX`), which isn't on the shared `ICacheStorageComponent` interface (and the in-memory fallback lacks it). Deferred to a proper interface extension rather than a fragile duck-typed lock; practical impact is at most a duplicate idempotent Magic deletion.
- **Nudge marked sent on email failure** — currently intended and locked in by `nudge-job.spec.ts`; changing it is a product decision (retry semantics vs. double-send risk).

## Testing

- `tsc --noEmit` clean, eslint clean
- 163/163 unit tests pass (incl. new CORS alternation test)
- 21/21 request-lifecycle integration tests pass (`with-polling.spec.ts`) — covers every centralized guard branch, status code, and socket relay path

🤖 Generated with [Claude Code](https://claude.com/claude-code)