### PR TITLE
feat: remove the dcl_personal_sign flow and block ephemeral message signing

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -16,9 +16,7 @@ CORS_METHODS=*
 # Redis host URL (e.g. redis://localhost:6379). If not set, in-memory cache is used.
 # REDIS_HOST=
 
-# Expiration time in seconds for the sign in request
-DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS=600
-# Expiration time in second for all other requests
+# Expiration time in seconds for requests
 REQUEST_EXPIRATION_IN_SECONDS=300
 
 # ── Magic account deletion ────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/decentraland/auth-server/badge.svg?branch=main)](https://coveralls.io/github/decentraland/auth-server?branch=main)
 
-This server facilitates communication between the Decentraland client and the auth dapp on the browser. It allows the client to execute wallet methods (`eth_sendTransaction`, `personal_sign`, etc.) using the wallet the user has on their browser by leveraging the auth dapp.
+This server facilitates communication between the Decentraland client and the auth dapp on the browser. It allows the client to execute wallet methods (`eth_sendTransaction`, `personal_sign`, etc.) using the wallet the user has on their browser by leveraging the auth dapp. The `dcl_personal_sign` method, and signing a Decentraland ephemeral message under any other method, are rejected — see [Requests](docs/requests.md#what-cannot-be-requested).
 
 ## Table of Contents
 
@@ -167,6 +167,7 @@ curl -X POST http://localhost:8080/admin/onboarding/send-test-email \
 ```
 
 Parameters:
+
 - `to` (string) — recipient email address
 - `checkpointId` (1–7) — which checkpoint's content to use
 - `sequence` (1, 2, 3) — which SendGrid template to use

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -4,7 +4,8 @@
 
 **Key Capabilities:**
 
-- Creates and manages request objects that encapsulate wallet method calls (eth_sendTransaction, personal_sign, dcl_personal_sign)
+- Creates and manages request objects that encapsulate wallet method calls (eth_sendTransaction, personal_sign)
+- Rejects the dcl_personal_sign method, and any request whose params carry a Decentraland ephemeral message, so the removed sign-in flow cannot be reproduced under another method name
 - Generates unique request IDs with expiration timestamps and visual verification codes
 - Relays wallet method execution results from browser dApp back to desktop client
 - Manages request lifecycle: creation, expiration, consumption, and cleanup on socket disconnect

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,7 +6,7 @@ info:
     API for Auth server with HTTP endpoints and Socket.IO WebSocket protocol.
 
     This server facilitates communication between the Decentraland clients and the auth dapp on the browser.
-    It allows the desktop client to execute wallet methods (eth_sendTransaction, personal_sign, etc.) using the wallet 
+    It allows the desktop client to execute wallet methods (eth_sendTransaction, personal_sign, etc.) using the wallet
     the user has on their browser.
 
     ### Request Lifecycle
@@ -26,9 +26,18 @@ info:
 
     ### Authentication
 
-    - For methods other than `dcl_personal_sign`, an `authChain` is required and will be validated.
-    - For `dcl_personal_sign`, no `authChain` is required initially.
+    - An `authChain` is required on every request and will be validated.
     - Signature validation is performed using `@dcl/crypto` Authenticator.
+
+    ### What cannot be requested
+
+    - The `dcl_personal_sign` method, in any casing.
+    - Signing a Decentraland ephemeral message under any other method: a request is refused when any
+      of its string params parses as one (`Ephemeral address:` / `Expiration:` lines), plain text or
+      hex-encoded. That payload is what mints an auth identity, so blocking only the method name
+      would leave the removed sign-in flow reproducible via `personal_sign` or `eth_sign`.
+    - Ordinary signing is unaffected: `personal_sign`, `eth_sign` and `eth_signTypedData*` are
+      accepted for messages that are not ephemeral messages.
   version: 1.0.0
   contact:
     name: Decentraland
@@ -143,9 +152,10 @@ paths:
         Creates a new authentication request that can be executed by the auth dapp.
 
         **Important:**
-        - For methods other than `dcl_personal_sign`, the `authChain` field is **required** and will be validated.
-        - For `dcl_personal_sign`, the `authChain` field is **optional**.
+        - The `authChain` field is **required** and will be validated.
         - Signature validation is performed using `@dcl/crypto` Authenticator.
+        - The `dcl_personal_sign` method is rejected, as is signing a Decentraland ephemeral message
+          under any other method. Ordinary `personal_sign` / `eth_sign` requests are accepted.
         - The request will expire after the configured expiration time (default: 5 minutes).
       operationId: createRequest
       security: []
@@ -170,12 +180,6 @@ paths:
                     - type: ECDSA_EPHEMERAL
                       payload: '...'
                       signature: '...'
-              dclPersonalSign:
-                summary: DCL personal sign request (no authChain required)
-                value:
-                  method: dcl_personal_sign
-                  params:
-                    - "DCL Signed Message:\nEphemeral address: 0x...\nExpiration: ..."
       responses:
         '201':
           description: Request created successfully
@@ -195,9 +199,17 @@ paths:
                 $ref: '#/components/schemas/InvalidResponseMessage'
               examples:
                 missingAuthChain:
-                  summary: Missing auth chain for non-dcl_personal_sign method
+                  summary: Missing auth chain
                   value:
                     error: 'Auth chain is required'
+                disallowedMethod:
+                  summary: dcl_personal_sign requested
+                  value:
+                    error: 'The dcl_personal_sign method is not allowed'
+                ephemeralMessagePayload:
+                  summary: Ephemeral message passed to a signing method
+                  value:
+                    error: 'Signing a Decentraland ephemeral message is not allowed'
                 invalidSignature:
                   summary: Signature validation failed
                   value:
@@ -661,7 +673,7 @@ components:
       properties:
         method:
           type: string
-          description: Wallet method to execute (e.g., 'eth_sendTransaction', 'personal_sign', 'dcl_personal_sign')
+          description: Wallet method to execute (e.g., 'eth_sendTransaction', 'personal_sign')
           example: 'personal_sign'
         params:
           type: array
@@ -671,12 +683,12 @@ components:
         authChain:
           $ref: '#/components/schemas/AuthChain'
           description: |
-            Optional authentication chain. 
-            **Required** for methods other than `dcl_personal_sign`.
-            **Optional** for `dcl_personal_sign` method.
+            Authentication chain of the wallet owner. **Required** — the signature is
+            validated and the owner address is stored as the request `sender`.
       required:
         - method
         - params
+        - authChain
       additionalProperties: false
     AuthChain:
       type: array
@@ -951,7 +963,8 @@ x-websocket:
         description: |
           Validates request structure and auth chain:
           - Validates JSON schema using Ajv
-          - For methods other than `dcl_personal_sign`, validates that authChain is present
+          - Rejects the dcl_personal_sign method and params carrying a Decentraland ephemeral message
+          - Validates that authChain is present
           - Validates authChain signature using @dcl/crypto Authenticator
           - Checks that ephemeral address can be extracted from authChain
     recover:
@@ -1054,7 +1067,7 @@ x-websocket:
     type: ethereum-signature
     description: |
       Ethereum signature validation via @dcl/crypto Authenticator.
-      - For non-dcl_personal_sign methods, authChain is validated on request creation
+      - authChain is validated on request creation
       - Signature validation ensures the request is authorized by the wallet owner
   cors:
     description: |

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -33,7 +33,8 @@ const socket = io('https://auth-api.decentraland.org')
 ```ts
 const { requestId, expiration, code } = await socket.emitWithAck('request', {
   method: 'personal_sign',
-  params: ['message to sign', 'signer address']
+  params: ['message to sign', 'signer address'],
+  authChain: identity.authChain
 })
 ```
 
@@ -75,7 +76,8 @@ const response = await fetch(`${authServerUrl}/requests`, {
   headers: [['Content-type', 'application/json']],
   body: JSON.stringify({
     method: 'personal_sign',
-    params: ['message to sign', 'signer address']
+    params: ['message to sign', 'signer address'],
+    authChain: identity.authChain
   })
 })
 const { requestId, expiration, code } = await response.json()
@@ -100,69 +102,28 @@ const outcome = await getResponse(requestId)
 
 3. Get the `result` and the `sender` from the outcome message and do with them whatever is necessary.
 
-### Authentication Flow
+### Authentication
 
-For the sign in flow in the desktop client, we will need to use a special method called `dcl_personal_sign`.
+Every request requires an `authChain` belonging to the wallet owner. The server validates its
+signature and stores the recovered owner address as the request `sender`, which is returned on the
+recover response. Requests without an `authChain` are rejected with `Auth chain is required`.
 
-This methods works similarly to `personal_sign` but with a little difference.
+### What cannot be requested
 
-For this example we'll be using `ethers v6` and `@dcl/crypto`
+Two things are refused, both when creating a request over the socket and over `POST /requests`:
 
-1. The desktop client will need to generate and store an epheremeral wallet.
+1. **The `dcl_personal_sign` method**, in any casing — rejected with
+   `The dcl_personal_sign method is not allowed`.
+2. **Signing a Decentraland ephemeral message under any other method** — rejected with
+   `Signing a Decentraland ephemeral message is not allowed`.
 
-```ts
-const ephemeralAccount = ethers.Wallet.createRandom()
-```
+The second rule exists because blocking the method name alone would not be enough: the ephemeral
+message is what actually mints an auth identity, so passing it to `personal_sign` or `eth_sign`
+would reproduce the removed sign-in flow exactly. A request is refused when any of its string
+params parses as an ephemeral message — that is, when it carries `Ephemeral address:` and
+`Expiration:` lines — whether sent as plain text or hex-encoded. The greeting on the first line is
+irrelevant, since any greeting yields a usable ephemeral auth link.
 
-2. The desktop client has to set a date in which the identity that will be created, expires.
-
-```ts
-const expiration = new Date(Date.now() + 24 * 60 * 60 * 1000) // 1 day in the future as an example.
-```
-
-3. Generate the ephemeral message to be signed using the address of the ephemeral account and the expiration.
-
-```ts
-const ephemeralMessage = Authenticator.getEphemeralMessage(ephemeralAccount.address, expiration)
-```
-
-4. Follow the steps decribed on the [Usage](#usage) section, initializing the flow with the following message.
-
-```ts
-await socket.emitWithAck('request', {
-  method: 'dcl_personal_sign',
-  params: [ephemeralMessage]
-})
-```
-
-As you can see, there is a simple difference with the previous example. That is that personal_sign requires a second parameter that is the address that will sign the message, but we don't know it yet, so only the ephemeral message is sent. The auth dApp will fill the signing address for us.
-
-If the signer is sent as a param in the request, the auth dapp will use that instead of using the one of the connected wallet, and execute it as a normal personal_sign.
-
-5. Once the flow is complete, and the desktop client receives the outcome message. The `sender` and the `result` that come with it are necessary to create an auth identity, which will be used to authorize the user into the platform.
-
-```ts
-const signer = outcome.sender
-const signature = outcome.result
-
-const identity = {
-  expiration,
-  ephemeralIdentity: {
-    address: ephemeralAccount.address,
-    privateKey: ephemeralAccount.privateKey,
-    publicKey: ephemeralAccount.publicKey
-  },
-  authChain: [
-    {
-      type: AuthLinkType.SIGNER,
-      payload: signer,
-      signature: ''
-    },
-    {
-      type: signature.length === 132 ? AuthLinkType.ECDSA_PERSONAL_EPHEMERAL : AuthLinkType.ECDSA_EIP_1654_EPHEMERAL,
-      payload: ephemeralMessage,
-      signature: signature
-    }
-  ]
-}
-```
+**Ordinary signing still works.** `personal_sign`, `eth_sign` and the `eth_signTypedData*` family
+are all accepted for messages that are not ephemeral messages, alongside non-signing methods such
+as `eth_sendTransaction`, `eth_call` and the `wallet_*` methods.

--- a/src/components.ts
+++ b/src/components.ts
@@ -29,7 +29,6 @@ import { AppComponents, GlobalContext } from './types'
 export async function initComponents(): Promise<AppComponents> {
   const config = await createDotEnvConfigComponent({ path: ['.env.default', '.env'] })
   const requestExpirationInSeconds = await config.requireNumber('REQUEST_EXPIRATION_IN_SECONDS')
-  const dclPersonalSignExpirationInSeconds = await config.requireNumber('DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS')
   const didTokenMaxAgeSeconds = await config.requireNumber('MAGIC_DID_TOKEN_MAX_AGE_SECONDS')
   const tracer = await createTracerComponent()
   const logs = await createLogComponent({ tracer })
@@ -86,7 +85,6 @@ export async function initComponents(): Promise<AppComponents> {
     { logs, storage, tracer, server },
     {
       requestExpirationInSeconds,
-      dclPersonalSignExpirationInSeconds,
       cors: { origin: cors.origin, methods: await config.requireString('CORS_METHODS') }
     }
   )

--- a/src/controllers/handlers/requests.ts
+++ b/src/controllers/handlers/requests.ts
@@ -9,9 +9,9 @@ import {
   MessageType,
   OutcomeResponseMessage,
   RecoverResponseMessage,
-  RequestMessage,
   RequestResponseMessage,
-  RequestValidationStatusMessage
+  RequestValidationStatusMessage,
+  ValidatedRequestMessage
 } from '../../ports/server/types'
 import { validateHttpOutcomeMessage, validateRequestMessage } from '../../ports/server/validations'
 import { StorageRequest } from '../../ports/storage/types'
@@ -32,7 +32,7 @@ export function createRequestHandler({ requestExpirationInSeconds }: RequestExpi
     } = context
 
     const data = await parseJsonBody(context.request)
-    let msg: RequestMessage
+    let msg: ValidatedRequestMessage
 
     try {
       msg = validateRequestMessage(data)
@@ -46,7 +46,7 @@ export function createRequestHandler({ requestExpirationInSeconds }: RequestExpi
     let sender: string
 
     try {
-      sender = (await validateAuthChain(msg.authChain || [])).sender
+      sender = (await validateAuthChain(msg.authChain)).sender
     } catch (e) {
       return {
         status: 400,

--- a/src/controllers/handlers/requests.ts
+++ b/src/controllers/handlers/requests.ts
@@ -3,7 +3,6 @@ import { v4 as uuid } from 'uuid'
 import { validateAuthChain } from '../../logic/auth-chain'
 import { isErrorWithMessage } from '../../logic/error-handling'
 import { loadActiveRequest, logInboundRequestStateError, RequestStateError, requestStateErrorToHttpResponse } from '../../logic/requests'
-import { METHOD_DCL_PERSONAL_SIGN } from '../../ports/server/constants'
 import {
   HttpOutcomeMessage,
   InvalidResponseMessage,
@@ -23,11 +22,10 @@ export type RequestsHandlerComponents = 'storage' | 'logs' | 'socketServer'
 
 export type RequestExpirationOptions = {
   requestExpirationInSeconds: number
-  dclPersonalSignExpirationInSeconds: number
 }
 
 // POST /requests — register a new request
-export function createRequestHandler({ requestExpirationInSeconds, dclPersonalSignExpirationInSeconds }: RequestExpirationOptions) {
+export function createRequestHandler({ requestExpirationInSeconds }: RequestExpirationOptions) {
   return async function requestHandler(context: HandlerContextWithPath<RequestsHandlerComponents, '/requests'>) {
     const {
       components: { storage }
@@ -45,24 +43,19 @@ export function createRequestHandler({ requestExpirationInSeconds, dclPersonalSi
       }
     }
 
-    let sender: string | undefined
+    let sender: string
 
-    if (msg.method !== METHOD_DCL_PERSONAL_SIGN) {
-      try {
-        const { sender: validatedSender } = await validateAuthChain(msg.authChain || [])
-        sender = validatedSender
-      } catch (e) {
-        return {
-          status: 400,
-          body: { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
-        }
+    try {
+      sender = (await validateAuthChain(msg.authChain || [])).sender
+    } catch (e) {
+      return {
+        status: 400,
+        body: { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
       }
     }
 
     const requestId = uuid()
-    const expiration = new Date(
-      Date.now() + (msg.method !== METHOD_DCL_PERSONAL_SIGN ? requestExpirationInSeconds : dclPersonalSignExpirationInSeconds) * 1000
-    )
+    const expiration = new Date(Date.now() + requestExpirationInSeconds * 1000)
     // Cryptographically secure so the pairing code the user visually confirms can't be predicted.
     const code = randomInt(0, 100)
 
@@ -72,7 +65,7 @@ export function createRequestHandler({ requestExpirationInSeconds, dclPersonalSi
       code,
       method: msg.method,
       params: msg.params,
-      sender: sender?.toLowerCase(),
+      sender: sender.toLowerCase(),
       requiresValidation: false
     })
 

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -25,7 +25,6 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   const onboardingApiKey = await config.requireString('ONBOARDING_API_KEY')
   const adminEnabled = (await config.getString('ONBOARDING_ADMIN_ENABLED')) === 'true'
   const requestExpirationInSeconds = await config.requireNumber('REQUEST_EXPIRATION_IN_SECONDS')
-  const dclPersonalSignExpirationInSeconds = await config.requireNumber('DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS')
 
   // Exact-match allowlist of browser Origins permitted to call the account
   // deletion endpoint (defense-in-depth on top of CORS). Empty disables the check.
@@ -70,7 +69,7 @@ export async function setupRouter(globalContext: GlobalContext): Promise<Router<
   router.get('/health/live', liveHandler)
 
   // Request lifecycle endpoints
-  router.post('/requests', createRequestHandler({ requestExpirationInSeconds, dclPersonalSignExpirationInSeconds }))
+  router.post('/requests', createRequestHandler({ requestExpirationInSeconds }))
   router.get('/v2/requests/:requestId', getRequestHandler)
   router.post('/v2/requests/:requestId/validation', notifyRequestValidationHandler)
   router.get('/v2/requests/:requestId/validation', getRequestValidationStatusHandler)

--- a/src/logic/auth-chain.ts
+++ b/src/logic/auth-chain.ts
@@ -2,6 +2,47 @@ import { Authenticator, parseEmphemeralPayload } from '@dcl/crypto'
 import { AuthChain } from '@dcl/schemas'
 
 /**
+ * Whether `value` is a Decentraland ephemeral message — the payload whose signature mints an auth
+ * identity, and what the removed `dcl_personal_sign` flow asked wallets to sign. Signing one over
+ * any other method (`personal_sign`, `eth_sign`, …) reproduces that flow exactly, so requests
+ * carrying such a payload are refused while ordinary signing stays allowed.
+ *
+ * Detection delegates to `@dcl/crypto`'s own parser so it cannot drift from the format the
+ * ephemeral auth links are validated against. That parser ignores the first line and only requires
+ * the `Ephemeral address:` / `Expiration:` lines, which is why matching the "Decentraland Login"
+ * greeting would not be enough — any greeting yields a usable ephemeral link.
+ */
+export function isEphemeralMessage(value: string): boolean {
+  return isEphemeralMessageText(value) || isEphemeralMessageText(decodeHexMessage(value))
+}
+
+function isEphemeralMessageText(value: string | undefined): boolean {
+  if (!value) {
+    return false
+  }
+
+  try {
+    parseEmphemeralPayload(value)
+    return true
+  } catch (e) {
+    // An expired payload is still an ephemeral message; the parser rejects it on some versions.
+    return e instanceof Error && e.message === 'Ephemeral payload has expired'
+  }
+}
+
+/**
+ * `personal_sign` takes its message hex-encoded as often as it takes plain text, so a hex payload
+ * has to be decoded before it can be recognised.
+ */
+function decodeHexMessage(value: string): string | undefined {
+  if (!/^0x[0-9a-f]*$/i.test(value) || value.length % 2 !== 0) {
+    return undefined
+  }
+
+  return Buffer.from(value.slice(2), 'hex').toString('utf8')
+}
+
+/**
  * Validates an auth chain and returns the owner address (`sender`) and the
  * ephemeral address (`finalAuthority`). Mirrors the validation used by the
  * socket `request` handler. Throws on any validation failure; the `Ephemeral

--- a/src/logic/socket-server/component.ts
+++ b/src/logic/socket-server/component.ts
@@ -11,7 +11,6 @@ import { ISocketServerComponent, SocketHandlerContext } from './types'
 
 export type SocketServerOptions = {
   requestExpirationInSeconds: number
-  dclPersonalSignExpirationInSeconds: number
   cors: {
     origin: RegExp[]
     methods: string
@@ -20,7 +19,7 @@ export type SocketServerOptions = {
 
 export async function createSocketServerComponent(
   { logs, storage, tracer, server }: Pick<AppComponents, 'logs' | 'storage' | 'tracer' | 'server'>,
-  { requestExpirationInSeconds, dclPersonalSignExpirationInSeconds, cors }: SocketServerOptions
+  { requestExpirationInSeconds, cors }: SocketServerOptions
 ): Promise<ISocketServerComponent> {
   const logger = logs.getLogger('websocket-server')
 
@@ -40,7 +39,7 @@ export async function createSocketServerComponent(
   const isSocketConnected: ISocketServerComponent['isSocketConnected'] = socketId => !!sockets[socketId]
 
   // Socket message handlers bound to their events + tracing spans — the socket analog of the HTTP router.
-  const routes = getSocketRoutes({ requestExpirationInSeconds, dclPersonalSignExpirationInSeconds })
+  const routes = getSocketRoutes({ requestExpirationInSeconds })
 
   const onConnection = (socket: Socket) =>
     tracer.span('websocket-connection', () => {

--- a/src/logic/socket-server/handlers/request.ts
+++ b/src/logic/socket-server/handlers/request.ts
@@ -1,6 +1,5 @@
 import { randomInt } from 'crypto'
 import { v4 as uuid } from 'uuid'
-import { METHOD_DCL_PERSONAL_SIGN } from '../../../ports/server/constants'
 import { InvalidResponseMessage, RequestMessage, RequestResponseMessage } from '../../../ports/server/types'
 import { validateRequestMessage } from '../../../ports/server/validations'
 import { validateAuthChain } from '../../auth-chain'
@@ -9,7 +8,6 @@ import { SocketHandlerContext, SocketMessageHandler } from '../types'
 
 export type SocketRequestExpirationOptions = {
   requestExpirationInSeconds: number
-  dclPersonalSignExpirationInSeconds: number
 }
 
 // REQUEST — registers a new auth request from a connected client and returns its id/code/expiration.
@@ -31,23 +29,18 @@ export function createRequestSocketHandler(options: SocketRequestExpirationOptio
       return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
     }
 
-    let sender: string | undefined
+    let sender: string
 
-    if (msg.method !== METHOD_DCL_PERSONAL_SIGN) {
-      // Same validation as the HTTP /requests handler (shared to avoid drift).
-      try {
-        sender = (await validateAuthChain(msg.authChain || [])).sender
-      } catch (e) {
-        logger.log('Received a request with an invalid auth chain')
-        return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
-      }
+    // Same validation as the HTTP /requests handler (shared to avoid drift).
+    try {
+      sender = (await validateAuthChain(msg.authChain || [])).sender
+    } catch (e) {
+      logger.log('Received a request with an invalid auth chain')
+      return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage
     }
 
     const requestId = uuid()
-    const expiration = new Date(
-      Date.now() +
-        (msg.method !== METHOD_DCL_PERSONAL_SIGN ? options.requestExpirationInSeconds : options.dclPersonalSignExpirationInSeconds) * 1000
-    )
+    const expiration = new Date(Date.now() + options.requestExpirationInSeconds * 1000)
     // Cryptographically secure so the pairing code the user visually confirms can't be predicted.
     const code = randomInt(0, 100)
 
@@ -59,7 +52,7 @@ export function createRequestSocketHandler(options: SocketRequestExpirationOptio
       code,
       method: msg.method,
       params: msg.params,
-      sender: sender?.toLowerCase()
+      sender: sender.toLowerCase()
     })
 
     logger.log(`[METHOD:${msg.method}][RID:${requestId}][EXP:${expiration.getTime()}] Successfully registered request response`)

--- a/src/logic/socket-server/handlers/request.ts
+++ b/src/logic/socket-server/handlers/request.ts
@@ -1,6 +1,6 @@
 import { randomInt } from 'crypto'
 import { v4 as uuid } from 'uuid'
-import { InvalidResponseMessage, RequestMessage, RequestResponseMessage } from '../../../ports/server/types'
+import { InvalidResponseMessage, RequestResponseMessage, ValidatedRequestMessage } from '../../../ports/server/types'
 import { validateRequestMessage } from '../../../ports/server/validations'
 import { validateAuthChain } from '../../auth-chain'
 import { isErrorWithMessage } from '../../error-handling'
@@ -21,7 +21,7 @@ export function createRequestSocketHandler(options: SocketRequestExpirationOptio
 
     logger.log('Received a request')
 
-    let msg: RequestMessage
+    let msg: ValidatedRequestMessage
     try {
       msg = validateRequestMessage(data)
     } catch (e) {
@@ -33,7 +33,7 @@ export function createRequestSocketHandler(options: SocketRequestExpirationOptio
 
     // Same validation as the HTTP /requests handler (shared to avoid drift).
     try {
-      sender = (await validateAuthChain(msg.authChain || [])).sender
+      sender = (await validateAuthChain(msg.authChain)).sender
     } catch (e) {
       logger.log('Received a request with an invalid auth chain')
       return { error: isErrorWithMessage(e) ? e.message : 'Unknown error' } satisfies InvalidResponseMessage

--- a/src/ports/server/constants.ts
+++ b/src/ports/server/constants.ts
@@ -1,5 +1,11 @@
-export const METHOD_DCL_PERSONAL_SIGN = 'dcl_personal_sign'
 export const ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1000
+
+/**
+ * Methods that can never be requested. `dcl_personal_sign` drove the sign-in flow this service no
+ * longer supports. Ordinary signing methods stay available — a request that tries to reproduce the
+ * flow under one of those names is rejected by its payload instead, see `isEphemeralMessage`.
+ */
+export const DISALLOWED_METHODS = new Set(['dcl_personal_sign'])
 
 // Max length constants for request/outcome validation
 export const MAX_METHOD_LENGTH = 256

--- a/src/ports/server/constants.ts
+++ b/src/ports/server/constants.ts
@@ -4,6 +4,12 @@ export const ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1000
  * Methods that can never be requested. `dcl_personal_sign` drove the sign-in flow this service no
  * longer supports. Ordinary signing methods stay available — a request that tries to reproduce the
  * flow under one of those names is rejected by its payload instead, see `isEphemeralMessage`.
+ *
+ * Refusing it does not strand the explorers or the creator hub: sign-in now goes through the
+ * identity endpoints instead of this relay. The auth dapp builds the whole auth identity itself and
+ * `POST /identities` stores it (validating the chain and that the ephemeral address matches its
+ * final authority), then the client collects it with `GET /identities/:id`. No ephemeral message is
+ * relayed as a wallet method any more, so there is no `dcl_personal_sign` request left to serve.
  */
 export const DISALLOWED_METHODS = new Set(['dcl_personal_sign'])
 

--- a/src/ports/server/types.ts
+++ b/src/ports/server/types.ts
@@ -15,8 +15,22 @@ export type Request = {
   params: any[]
 }
 
+/**
+ * A `request` message as it arrives from a client, before validation. `authChain` is optional here
+ * because that is the truth about untrusted input, not because it is optional in the API contract —
+ * see `ValidatedRequestMessage`.
+ */
 export type RequestMessage = Request & {
   authChain?: AuthChain
+}
+
+/**
+ * A `request` message that has passed `validateRequestMessage`. The auth chain is required on every
+ * request (as `docs/openapi.yaml` declares), and the validator guarantees it is present, so
+ * handlers can hand it straight to `validateAuthChain` without a fallback.
+ */
+export type ValidatedRequestMessage = RequestMessage & {
+  authChain: AuthChain
 }
 
 export type LiveResponseMessage = {

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -13,7 +13,8 @@ import {
   RequestValidationMessage,
   IdentityRequest,
   CheckpointRequest,
-  AccountDeletionMetadata
+  AccountDeletionMetadata,
+  ValidatedRequestMessage
 } from './types'
 
 const ajv = new Ajv({ allowUnionTypes: true })
@@ -32,6 +33,10 @@ const requestMessageSchema = {
     },
     authChain: AuthChain.schema
   },
+  // `authChain` is required on every request, but deliberately not listed here: presence is checked
+  // right after this schema runs so a client gets `Auth chain is required` instead of an Ajv error
+  // blob. `validateRequestMessage` is what guarantees the field, and it narrows its return type to
+  // `ValidatedRequestMessage` to say so.
   required: ['method', 'params'],
   additionalProperties: false
 }
@@ -237,15 +242,15 @@ export function isDisallowedMethod(method: string): boolean {
   return DISALLOWED_METHODS.has(method.trim().toLowerCase())
 }
 
-export function validateRequestMessage(msg: unknown) {
+export function validateRequestMessage(msg: unknown): ValidatedRequestMessage {
   if (!requestMessageValidator(msg)) {
     throw new Error(JSON.stringify(requestMessageValidator.errors))
   }
 
   const requestMessage = msg as RequestMessage
 
-  // Both checks live here rather than in either handler so the socket and HTTP entry points, which
-  // share this validator, cannot drift apart on what they accept.
+  // Every check below lives here rather than in either handler so the socket and HTTP entry points,
+  // which share this validator, cannot drift apart on what they accept.
   if (isDisallowedMethod(requestMessage.method)) {
     // Normalised so the message is identical whatever casing the caller used.
     throw new Error(`The ${requestMessage.method.trim().toLowerCase()} method is not allowed`)
@@ -257,7 +262,13 @@ export function validateRequestMessage(msg: unknown) {
     throw new Error('Signing a Decentraland ephemeral message is not allowed')
   }
 
-  return requestMessage
+  // Checked last so a caller on a retired flow is told which method to stop using, rather than being
+  // sent to fix an auth chain on a request that would be refused regardless.
+  if (!requestMessage.authChain) {
+    throw new Error('Auth chain is required')
+  }
+
+  return requestMessage as ValidatedRequestMessage
 }
 
 export function validateRecoverMessage(msg: unknown) {

--- a/src/ports/server/validations.ts
+++ b/src/ports/server/validations.ts
@@ -2,8 +2,9 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import { InvalidRequestError } from '@dcl/http-commons'
 import { AuthChain } from '@dcl/schemas'
+import { isEphemeralMessage } from '../../logic/auth-chain'
 import { SimulationRequestBody } from '../../logic/simulation/types'
-import { MAX_METHOD_LENGTH, MAX_PARAMS_ITEMS, MAX_ERROR_MESSAGE_LENGTH, MAX_REQUEST_ID_LENGTH } from './constants'
+import { DISALLOWED_METHODS, MAX_METHOD_LENGTH, MAX_PARAMS_ITEMS, MAX_ERROR_MESSAGE_LENGTH, MAX_REQUEST_ID_LENGTH } from './constants'
 import {
   HttpOutcomeMessage,
   OutcomeMessage,
@@ -231,12 +232,32 @@ const checkpointRequestValidator = ajv.compile(checkpointRequestSchema)
 const accountDeletionMetadataValidator = ajv.compile(accountDeletionMetadataSchema)
 const simulationRequestValidator = ajv.compile(simulationRequestSchema)
 
+/** Whether `method` is one this service refuses to create requests for. See `DISALLOWED_METHODS`. */
+export function isDisallowedMethod(method: string): boolean {
+  return DISALLOWED_METHODS.has(method.trim().toLowerCase())
+}
+
 export function validateRequestMessage(msg: unknown) {
   if (!requestMessageValidator(msg)) {
     throw new Error(JSON.stringify(requestMessageValidator.errors))
   }
 
-  return msg as RequestMessage
+  const requestMessage = msg as RequestMessage
+
+  // Both checks live here rather than in either handler so the socket and HTTP entry points, which
+  // share this validator, cannot drift apart on what they accept.
+  if (isDisallowedMethod(requestMessage.method)) {
+    // Normalised so the message is identical whatever casing the caller used.
+    throw new Error(`The ${requestMessage.method.trim().toLowerCase()} method is not allowed`)
+  }
+
+  // Refuse any method used to sign a Decentraland ephemeral message, which would reproduce the
+  // removed dcl_personal_sign flow under a different name.
+  if (requestMessage.params.some(param => typeof param === 'string' && isEphemeralMessage(param))) {
+    throw new Error('Signing a Decentraland ephemeral message is not allowed')
+  }
+
+  return requestMessage
 }
 
 export function validateRecoverMessage(msg: unknown) {

--- a/test/components.ts
+++ b/test/components.ts
@@ -31,7 +31,6 @@ export { createMockDbComponent, createMockLogs }
 
 type TestOverrides = {
   requestExpirationInSeconds?: number
-  dclPersonalSignExpirationInSeconds?: number
   didTokenMaxAgeSeconds?: number
 }
 
@@ -124,10 +123,9 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
       HTTP_SERVER_PORT: httpServerPort.toString(),
       CORS_ORIGIN: 'https://test-*.org;https://test-*.zone',
       ACCOUNT_DELETION_ALLOWED_ORIGINS: 'https://account.decentraland.org',
-      // Expiration values are read from config by both the HTTP request handlers and the
+      // The expiration value is read from config by both the HTTP request handlers and the
       // socket-server, so per-test overrides are injected here as config defaults.
-      REQUEST_EXPIRATION_IN_SECONDS: String(overrides.requestExpirationInSeconds ?? 5 * 60), // 5 Minutes
-      DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS: String(overrides.dclPersonalSignExpirationInSeconds ?? 5 * 60) // 5 Minutes
+      REQUEST_EXPIRATION_IN_SECONDS: String(overrides.requestExpirationInSeconds ?? 5 * 60) // 5 Minutes
     }
   )
 
@@ -184,7 +182,6 @@ async function initComponents(overrides: TestOverrides = {}): Promise<TestCompon
     { logs, storage, tracer, server },
     {
       requestExpirationInSeconds: overrides.requestExpirationInSeconds ?? 5 * 60, // 5 Minutes
-      dclPersonalSignExpirationInSeconds: overrides.dclPersonalSignExpirationInSeconds ?? 5 * 60, // 5 Minutes
       cors: { origin: cors.origin, methods: await config.requireString('CORS_METHODS') }
     }
   )

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -1,7 +1,7 @@
 import { Socket } from 'socket.io-client'
+import { Authenticator, AuthIdentity } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
 import { TestArguments } from '@dcl/test-helpers'
-import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
 import { MessageType, RequestResponseMessage, RequestValidationMessage } from '../../src/ports/server/types'
 import { BaseComponents } from '../../src/types'
 import { test, testWithOverrides } from '../components'
@@ -39,6 +39,29 @@ function connectClients(args: TestArguments<BaseComponents>) {
   }
 }
 
+/**
+ * Creates a fresh auth identity for the enclosing `test()`/`describe` context. Every request
+ * requires a valid auth chain, so each test that registers one needs an identity. Registers its
+ * own `beforeEach` so the identity is scoped to the current test.
+ */
+function useTestIdentity() {
+  let identity: AuthIdentity
+
+  beforeEach(async () => {
+    identity = await createTestIdentity()
+  })
+
+  return {
+    get authChain(): AuthIdentity['authChain'] {
+      return identity.authChain
+    },
+    /** The owner address the server derives from the auth chain and stores as the request sender. */
+    get owner(): string {
+      return identity.authChain[0].payload.toLowerCase()
+    }
+  }
+}
+
 test('when sending a request message with an invalid schema', args => {
   const clients = connectClients(args)
 
@@ -55,23 +78,6 @@ test('when sending a request message with an invalid schema', args => {
 test('when sending a request message', args => {
   const clients = connectClients(args)
 
-  it('should respond with a request response message', async () => {
-    const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
-    })
-
-    expect(response).toEqual({
-      requestId: expect.any(String),
-      expiration: expect.any(String),
-      code: expect.any(Number)
-    })
-  })
-})
-
-test(`when sending a request message for a method that is not ${METHOD_DCL_PERSONAL_SIGN}`, args => {
-  const clients = connectClients(args)
-
   describe('and an auth chain is not provided', () => {
     it('should respond with an invalid response message indicating that the auth chain is required', async () => {
       const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
@@ -85,18 +91,84 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
     })
   })
 
-  describe('and an auth chain is provided', () => {
-    let testIdentity: Awaited<ReturnType<typeof createTestIdentity>>
+  describe('and the method is dcl_personal_sign', () => {
+    const identity = useTestIdentity()
 
-    beforeEach(async () => {
-      testIdentity = await createTestIdentity()
+    it('should respond with an invalid response message indicating that the method is not allowed', async () => {
+      const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
+        method: 'dcl_personal_sign',
+        params: [],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'The dcl_personal_sign method is not allowed'
+      })
     })
+  })
+
+  describe('and the method signs a Decentraland ephemeral message', () => {
+    const identity = useTestIdentity()
+    let ephemeralMessage: string
+
+    beforeEach(() => {
+      ephemeralMessage = Authenticator.getEphemeralMessage(
+        '0x1234567890123456789012345678901234567890',
+        new Date(Date.now() + 24 * 60 * 60 * 1000)
+      )
+    })
+
+    it('should respond with an invalid response message indicating that signing an ephemeral message is not allowed', async () => {
+      const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
+        method: 'personal_sign',
+        params: [ephemeralMessage],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'Signing a Decentraland ephemeral message is not allowed'
+      })
+    })
+
+    it('should respond with an invalid response message when the ephemeral message is hex encoded', async () => {
+      const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
+        method: 'personal_sign',
+        params: [`0x${Buffer.from(ephemeralMessage, 'utf8').toString('hex')}`],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'Signing a Decentraland ephemeral message is not allowed'
+      })
+    })
+  })
+
+  describe('and the method signs an ordinary message', () => {
+    const identity = useTestIdentity()
+
+    it('should respond with a request response message', async () => {
+      const response = await clients.desktop.emitWithAck(MessageType.REQUEST, {
+        method: 'personal_sign',
+        params: ['Please sign to confirm your order', '0x1234567890123456789012345678901234567890'],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        requestId: expect.any(String),
+        expiration: expect.any(String),
+        code: expect.any(Number)
+      })
+    })
+  })
+
+  describe('and an auth chain is provided', () => {
+    const identity = useTestIdentity()
 
     it('should respond with a request response message', async () => {
       const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
         method: 'method',
         params: [],
-        authChain: testIdentity.authChain
+        authChain: identity.authChain
       })
 
       expect(requestResponse).toEqual({
@@ -110,23 +182,23 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
       const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
         method: 'method',
         params: [],
-        authChain: testIdentity.authChain
+        authChain: identity.authChain
       })
 
       const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
         requestId: requestResponse.requestId
       })
 
-      expect(recoverResponse.sender).toEqual(testIdentity.authChain[0].payload.toLowerCase())
+      expect(recoverResponse.sender).toEqual(identity.owner)
     })
 
     describe('and the payload on the signer link does not match the address of the ephemeral message signer', () => {
       let otherAccount: ReturnType<typeof createUnsafeIdentity>
-      let modifiedAuthChain: typeof testIdentity.authChain
+      let modifiedAuthChain: AuthIdentity['authChain']
 
       beforeEach(() => {
         otherAccount = createUnsafeIdentity()
-        modifiedAuthChain = [...testIdentity.authChain]
+        modifiedAuthChain = [...identity.authChain]
         modifiedAuthChain[0] = {
           ...modifiedAuthChain[0],
           payload: otherAccount.address
@@ -141,16 +213,18 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
         })
 
         expect(requestResponse.error).toEqual(
-          `ERROR. Link type: ECDSA_EPHEMERAL. Invalid signer address. Expected: ${otherAccount.address.toLowerCase()}. Actual: ${testIdentity.authChain[0].payload.toLowerCase()}.`
+          `ERROR. Link type: ECDSA_EPHEMERAL. Invalid signer address. Expected: ${otherAccount.address.toLowerCase()}. Actual: ${
+            identity.owner
+          }.`
         )
       })
     })
 
     describe('and the auth chain does not have a parsable payload in the second link', () => {
-      let modifiedAuthChain: typeof testIdentity.authChain
+      let modifiedAuthChain: AuthIdentity['authChain']
 
       beforeEach(() => {
-        modifiedAuthChain = [...testIdentity.authChain]
+        modifiedAuthChain = [...identity.authChain]
         modifiedAuthChain[1] = {
           ...modifiedAuthChain[1],
           payload: 'unparsable'
@@ -200,13 +274,15 @@ test('when sending a recover message but the request does not exist', args => {
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
+testWithOverrides({ requestExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
@@ -221,16 +297,19 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending a re
 
 test('when sending a recover message for a request that has been overridden by another one', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
@@ -244,13 +323,15 @@ test('when sending a recover message for a request that has been overridden by a
 
   it('should respond with a recover response message for the new request', async () => {
     await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
@@ -260,20 +341,23 @@ test('when sending a recover message for a request that has been overridden by a
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
       code: requestResponse.code,
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      sender: identity.owner
     })
   })
 
   it('should not override the first request if it was sent by a different socket', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     await clients.authDapp.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
@@ -283,19 +367,22 @@ test('when sending a recover message for a request that has been overridden by a
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
       code: requestResponse.code,
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      sender: identity.owner
     })
   })
 })
 
 test('when sending a recover message but the socket that sent it has disconnected', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
 
   it('should still return the request data (requests survive socket disconnect)', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     clients.desktop.disconnect()
@@ -307,19 +394,22 @@ test('when sending a recover message but the socket that sent it has disconnecte
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
       code: requestResponse.code,
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      sender: identity.owner
     })
   })
 })
 
 test('when sending a recover message', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with a recover response message', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const recoverResponse = await clients.authDapp.emitWithAck(MessageType.RECOVER, {
@@ -329,8 +419,9 @@ test('when sending a recover message', args => {
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
       code: requestResponse.code,
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      sender: identity.owner
     })
   })
 })
@@ -371,8 +462,9 @@ test('when sending an outcome message but the request does not exist', args => {
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
+testWithOverrides({ requestExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
   let sender: string
 
   beforeEach(() => {
@@ -381,8 +473,9 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an o
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const outcomeResponse = await clients.authDapp.emitWithAck(MessageType.OUTCOME, {
@@ -399,6 +492,7 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an o
 
 test('when sending an outcome message but the socket that created the request disconnected', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
   let sender: string
 
   beforeEach(() => {
@@ -407,8 +501,9 @@ test('when sending an outcome message but the socket that created the request di
 
   it('should accept the outcome and store it for polling (requests survive socket disconnect)', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     clients.desktop.disconnect()
@@ -425,6 +520,7 @@ test('when sending an outcome message but the socket that created the request di
 
 test('when the auth dapp sends an outcome message', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
   let sender: string
 
   beforeEach(() => {
@@ -433,8 +529,9 @@ test('when the auth dapp sends an outcome message', args => {
 
   it('should respond with an empty object as ack', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const outcomeResponse = await clients.authDapp.emitWithAck(MessageType.OUTCOME, {
@@ -448,8 +545,9 @@ test('when the auth dapp sends an outcome message', args => {
 
   it('should emit to the desktop client the outcome response message', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const outcomeResponsePromise = new Promise(resolve => {
@@ -475,8 +573,9 @@ test('when the auth dapp sends an outcome message', args => {
 
   it('should emit to the desktop client the outcome response message with an error', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     const outcomeResponsePromise = new Promise(resolve => {
@@ -508,8 +607,9 @@ test('when the auth dapp sends an outcome message', args => {
 
   it('should respond with an invalid response message if calling the output twice', async () => {
     const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
 
     await clients.authDapp.emitWithAck(MessageType.OUTCOME, {
@@ -530,27 +630,26 @@ test('when the auth dapp sends an outcome message', args => {
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
-  'when posting that a request needs validation but the request has expired',
-  args => {
-    const clients = connectClients(args)
+testWithOverrides({ requestExpirationInSeconds: -1 })('when posting that a request needs validation but the request has expired', args => {
+  const clients = connectClients(args)
+  const identity = useTestIdentity()
 
-    it('should respond with an error indicating that the request has expired', async () => {
-      const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
-      })
-
-      const response = await clients.authDapp.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
-        requestId: requestResponse.requestId
-      })
-
-      expect(response).toEqual({
-        error: `Request with id "${requestResponse.requestId}" has expired`
-      })
+  it('should respond with an error indicating that the request has expired', async () => {
+    const requestResponse = await clients.desktop.emitWithAck(MessageType.REQUEST, {
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })
-  }
-)
+
+    const response = await clients.authDapp.emitWithAck(MessageType.REQUEST_VALIDATION_STATUS, {
+      requestId: requestResponse.requestId
+    })
+
+    expect(response).toEqual({
+      error: `Request with id "${requestResponse.requestId}" has expired`
+    })
+  })
+})
 
 test('when posting that a request needs validation but the request does not exist', args => {
   const clients = connectClients(args)
@@ -571,14 +670,16 @@ test('when posting that a request needs validation but the request does not exis
 
 test('when posting that a request needs validation and the request is valid', args => {
   const clients = connectClients(args)
+  const identity = useTestIdentity()
 
   describe('and there is a client connected listening for the request validation', () => {
     let requestResponse: RequestResponseMessage
 
     beforeEach(async () => {
       requestResponse = (await clients.desktop.emitWithAck('request', {
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
+        method: 'method',
+        params: [],
+        authChain: identity.authChain
       })) as RequestResponseMessage
     })
 
@@ -605,8 +706,9 @@ test('when posting that a request needs validation and the request is valid', ar
 
     beforeEach(async () => {
       requestResponse = (await clients.desktop.emitWithAck(MessageType.REQUEST, {
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
+        method: 'method',
+        params: [],
+        authChain: identity.authChain
       })) as RequestResponseMessage
     })
 

--- a/test/integration/with-polling.spec.ts
+++ b/test/integration/with-polling.spec.ts
@@ -1,8 +1,7 @@
 import { Socket } from 'socket.io-client'
-import { AuthIdentity } from '@dcl/crypto'
+import { Authenticator, AuthIdentity } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
 import { TestArguments } from '@dcl/test-helpers'
-import { METHOD_DCL_PERSONAL_SIGN } from '../../src/ports/server/constants'
 import { MessageType, OutcomeResponseMessage, RequestResponseMessage, RequestValidationMessage } from '../../src/ports/server/types'
 import { BaseComponents } from '../../src/types'
 import { test, testWithOverrides } from '../components'
@@ -46,6 +45,29 @@ function usePollingClients(args: TestArguments<BaseComponents>, { withWebSocket 
   }
 }
 
+/**
+ * Creates a fresh auth identity for the enclosing `test()`/`describe` context. Every request
+ * requires a valid auth chain, so each test that registers one needs an identity. Registers its
+ * own `beforeEach` so the identity is scoped to the current test.
+ */
+function useTestIdentity() {
+  let identity: AuthIdentity
+
+  beforeEach(async () => {
+    identity = await createTestIdentity()
+  })
+
+  return {
+    get authChain(): AuthIdentity['authChain'] {
+      return identity.authChain
+    },
+    /** The owner address the server derives from the auth chain and stores as the request sender. */
+    get owner(): string {
+      return identity.authChain[0].payload.toLowerCase()
+    }
+  }
+}
+
 test('when sending a request message with an invalid schema', args => {
   const clients = usePollingClients(args)
 
@@ -59,7 +81,7 @@ test('when sending a request message with an invalid schema', args => {
   })
 })
 
-test(`when sending a request message for a method that is not ${METHOD_DCL_PERSONAL_SIGN}`, args => {
+test('when sending a request message', args => {
   const clients = usePollingClients(args)
 
   describe('and an auth chain is not provided', () => {
@@ -75,18 +97,84 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
     })
   })
 
-  describe('and an auth chain is provided', () => {
-    let testIdentity: AuthIdentity
+  describe('and the method is dcl_personal_sign', () => {
+    const identity = useTestIdentity()
 
-    beforeEach(async () => {
-      testIdentity = await createTestIdentity()
+    it('should respond with an invalid response message indicating that the method is not allowed', async () => {
+      const response = await clients.http.request({
+        method: 'dcl_personal_sign',
+        params: [],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'The dcl_personal_sign method is not allowed'
+      })
     })
+  })
+
+  describe('and the method signs a Decentraland ephemeral message', () => {
+    const identity = useTestIdentity()
+    let ephemeralMessage: string
+
+    beforeEach(() => {
+      ephemeralMessage = Authenticator.getEphemeralMessage(
+        '0x1234567890123456789012345678901234567890',
+        new Date(Date.now() + 24 * 60 * 60 * 1000)
+      )
+    })
+
+    it('should respond with an invalid response message indicating that signing an ephemeral message is not allowed', async () => {
+      const response = await clients.http.request({
+        method: 'personal_sign',
+        params: [ephemeralMessage],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'Signing a Decentraland ephemeral message is not allowed'
+      })
+    })
+
+    it('should respond with an invalid response message when the ephemeral message is hex encoded', async () => {
+      const response = await clients.http.request({
+        method: 'personal_sign',
+        params: [`0x${Buffer.from(ephemeralMessage, 'utf8').toString('hex')}`],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        error: 'Signing a Decentraland ephemeral message is not allowed'
+      })
+    })
+  })
+
+  describe('and the method signs an ordinary message', () => {
+    const identity = useTestIdentity()
+
+    it('should respond with the data of the request', async () => {
+      const response = await clients.http.request({
+        method: 'personal_sign',
+        params: ['Please sign to confirm your order', '0x1234567890123456789012345678901234567890'],
+        authChain: identity.authChain
+      })
+
+      expect(response).toEqual({
+        requestId: expect.any(String),
+        expiration: expect.any(String),
+        code: expect.any(Number)
+      })
+    })
+  })
+
+  describe('and an auth chain is provided', () => {
+    const identity = useTestIdentity()
 
     it('should respond with the data of the request', async () => {
       const requestResponse = await clients.http.request({
         method: 'method',
         params: [],
-        authChain: testIdentity.authChain
+        authChain: identity.authChain
       })
 
       expect(requestResponse).toEqual({
@@ -100,21 +188,21 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
       const requestResponse = (await clients.http.request({
         method: 'method',
         params: [],
-        authChain: testIdentity.authChain
+        authChain: identity.authChain
       })) as RequestResponseMessage
 
       const recoverResponse = await clients.http.recover(requestResponse.requestId)
 
-      expect(recoverResponse.sender).toEqual(testIdentity.authChain[0].payload.toLowerCase())
+      expect(recoverResponse.sender).toEqual(identity.owner)
     })
 
     describe('and the payload on the signer link does not match the address of the ephemeral message signer', () => {
       let otherAccount: ReturnType<typeof createUnsafeIdentity>
-      let modifiedAuthChain: typeof testIdentity.authChain
+      let modifiedAuthChain: AuthIdentity['authChain']
 
       beforeEach(() => {
         otherAccount = createUnsafeIdentity()
-        modifiedAuthChain = [...testIdentity.authChain]
+        modifiedAuthChain = [...identity.authChain]
         modifiedAuthChain[0] = {
           ...modifiedAuthChain[0],
           payload: otherAccount.address
@@ -129,16 +217,18 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
         })) as { error: string }
 
         expect(requestResponse.error).toEqual(
-          `ERROR. Link type: ECDSA_EPHEMERAL. Invalid signer address. Expected: ${otherAccount.address.toLowerCase()}. Actual: ${testIdentity.authChain[0].payload.toLowerCase()}.`
+          `ERROR. Link type: ECDSA_EPHEMERAL. Invalid signer address. Expected: ${otherAccount.address.toLowerCase()}. Actual: ${
+            identity.owner
+          }.`
         )
       })
     })
 
     describe('and the auth chain does not have a parsable payload in the second link', () => {
-      let modifiedAuthChain: typeof testIdentity.authChain
+      let modifiedAuthChain: AuthIdentity['authChain']
 
       beforeEach(() => {
-        modifiedAuthChain = [...testIdentity.authChain]
+        modifiedAuthChain = [...identity.authChain]
         modifiedAuthChain[1] = {
           ...modifiedAuthChain[1],
           payload: 'unparsable'
@@ -158,13 +248,15 @@ test(`when sending a request message for a method that is not ${METHOD_DCL_PERSO
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
+testWithOverrides({ requestExpirationInSeconds: -1 })('when sending a recover message but the request has expired', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     const recoverResponse = await clients.http.recover(requestResponse.requestId)
@@ -177,11 +269,13 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending a re
 
 test('when sending a recover message', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with the recover data of the request', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     const recoverResponse = await clients.http.recover(requestResponse.requestId)
@@ -189,19 +283,22 @@ test('when sending a recover message', args => {
     expect(recoverResponse).toEqual({
       expiration: requestResponse.expiration,
       code: requestResponse.code,
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      sender: identity.owner
     })
   })
 })
 
 test('when sending an outcome message with an invalid schema', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     const response = await clients.http.sendSuccessfulOutcome(requestResponse.requestId, 'sender', undefined)
@@ -232,8 +329,9 @@ test('when sending an outcome message but the request does not exist', args => {
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
+testWithOverrides({ requestExpirationInSeconds: -1 })('when sending an outcome message but the request has expired', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
   let sender: string
 
   beforeEach(() => {
@@ -242,8 +340,9 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an o
 
   it('should respond with an invalid response message', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     const outcomeResponse = await clients.http.sendSuccessfulOutcome(requestResponse.requestId, sender, 'result')
@@ -256,6 +355,7 @@ testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })('when sending an o
 
 test('when sending a valid outcome message with the HTTP endpoints', args => {
   const clients = usePollingClients(args, { withWebSocket: true })
+  const identity = useTestIdentity()
   let sender: string
 
   beforeEach(() => {
@@ -264,8 +364,9 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
 
   it('should respond with the outcome response message', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     await clients.http.sendSuccessfulOutcome(requestResponse.requestId, sender, 'result')
@@ -281,8 +382,9 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
 
   it('should relay the HTTP-submitted outcome to the connected websocket client', async () => {
     const requestResponse = (await clients.ws.emitWithAck('request', {
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     const promiseOfAnOutcome = new Promise<OutcomeResponseMessage>((resolve, _) => {
@@ -302,8 +404,9 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
 
   it('should respond with the outcome response message with an error', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     await clients.http.sendFailedOutcome(requestResponse.requestId, sender, {
@@ -325,8 +428,9 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
 
   it('should respond with an invalid response message if calling the output twice', async () => {
     const requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     await clients.http.sendSuccessfulOutcome(requestResponse.requestId, sender, 'result')
@@ -339,25 +443,24 @@ test('when sending a valid outcome message with the HTTP endpoints', args => {
   })
 })
 
-testWithOverrides({ dclPersonalSignExpirationInSeconds: -1 })(
-  'when posting that a request needs validation but the request has expired',
-  args => {
-    const clients = usePollingClients(args)
+testWithOverrides({ requestExpirationInSeconds: -1 })('when posting that a request needs validation but the request has expired', args => {
+  const clients = usePollingClients(args)
+  const identity = useTestIdentity()
 
-    it('should respond with a 410 and an expired response message', async () => {
-      const requestResponse = (await clients.http.request({
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
-      })) as RequestResponseMessage
+  it('should respond with a 410 and an expired response message', async () => {
+    const requestResponse = (await clients.http.request({
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
+    })) as RequestResponseMessage
 
-      const response = await clients.http.notifyRequestValidation(requestResponse.requestId)
+    const response = await clients.http.notifyRequestValidation(requestResponse.requestId)
 
-      expect(response).toEqual({
-        error: `Request with id "${requestResponse.requestId}" has expired`
-      })
+    expect(response).toEqual({
+      error: `Request with id "${requestResponse.requestId}" has expired`
     })
-  }
-)
+  })
+})
 
 test('when posting that a request needs validation but the request does not exist', args => {
   const clients = usePollingClients(args)
@@ -378,14 +481,16 @@ test('when posting that a request needs validation but the request does not exis
 
 test('when posting that a request needs validation and the request is valid', args => {
   const clients = usePollingClients(args, { withWebSocket: true })
+  const identity = useTestIdentity()
 
   describe('and there is a client connected listening for the request validation', () => {
     let requestResponse: RequestResponseMessage
 
     beforeEach(async () => {
       requestResponse = (await clients.ws.emitWithAck('request', {
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
+        method: 'method',
+        params: [],
+        authChain: identity.authChain
       })) as RequestResponseMessage
     })
 
@@ -409,8 +514,9 @@ test('when posting that a request needs validation and the request is valid', ar
 
     beforeEach(async () => {
       requestResponse = (await clients.http.request({
-        method: METHOD_DCL_PERSONAL_SIGN,
-        params: []
+        method: 'method',
+        params: [],
+        authChain: identity.authChain
       })) as RequestResponseMessage
     })
 
@@ -422,12 +528,14 @@ test('when posting that a request needs validation and the request is valid', ar
 
 test('when getting the request validation status of a request that should not be validated', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
   let requestResponse: RequestResponseMessage
 
   beforeEach(async () => {
     requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
   })
 
@@ -442,12 +550,14 @@ test('when getting the request validation status of a request that should not be
 
 test('when getting the request validation status of a request that should be validated', args => {
   const clients = usePollingClients(args)
+  const identity = useTestIdentity()
   let requestResponse: RequestResponseMessage
 
   beforeEach(async () => {
     requestResponse = (await clients.http.request({
-      method: METHOD_DCL_PERSONAL_SIGN,
-      params: []
+      method: 'method',
+      params: [],
+      authChain: identity.authChain
     })) as RequestResponseMessage
 
     await clients.http.notifyRequestValidation(requestResponse.requestId)

--- a/test/unit/validations.spec.ts
+++ b/test/unit/validations.spec.ts
@@ -1,4 +1,6 @@
+import { Authenticator } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
+import { isEphemeralMessage } from '../../src/logic/auth-chain'
 import { MAX_METHOD_LENGTH, MAX_PARAMS_ITEMS, MAX_ERROR_MESSAGE_LENGTH, MAX_REQUEST_ID_LENGTH } from '../../src/ports/server/constants'
 import {
   RequestMessage,
@@ -15,7 +17,8 @@ import {
   validateRequestValidationMessage,
   validateIdentityId,
   validateHttpOutcomeMessage,
-  validateIdentityRequest
+  validateIdentityRequest,
+  isDisallowedMethod
 } from '../../src/ports/server/validations'
 import { generateRandomIdentityId, createTestIdentity } from '../utils/test-identity'
 
@@ -92,6 +95,212 @@ describe('when validating request messages', () => {
 
     it('should return a message with the max number of params', () => {
       expect(validateRequestMessage(messageWithMaxParams).params).toHaveLength(MAX_PARAMS_ITEMS)
+    })
+  })
+
+  describe('and the method is dcl_personal_sign', () => {
+    let messageWithDclPersonalSign: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithDclPersonalSign = { method: 'dcl_personal_sign', params: [] }
+    })
+
+    it('should throw an error indicating that the dcl_personal_sign method is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithDclPersonalSign)).toThrow('The dcl_personal_sign method is not allowed')
+    })
+  })
+
+  describe('and the method is dcl_personal_sign written in a different casing', () => {
+    let messageWithMixedCaseMethod: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithMixedCaseMethod = { method: 'DCL_Personal_Sign', params: [] }
+    })
+
+    it('should throw an error indicating that the dcl_personal_sign method is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithMixedCaseMethod)).toThrow('The dcl_personal_sign method is not allowed')
+    })
+  })
+
+  describe('and the method is personal_sign for an ordinary message', () => {
+    let messageWithPersonalSign: RequestMessage
+
+    beforeEach(() => {
+      messageWithPersonalSign = {
+        method: 'personal_sign',
+        params: ['Please sign to confirm your order', '0x1234567890123456789012345678901234567890']
+      }
+    })
+
+    it('should return the validated message', () => {
+      expect(validateRequestMessage(messageWithPersonalSign)).toEqual(messageWithPersonalSign)
+    })
+  })
+
+  describe('and the method is personal_sign for a Decentraland ephemeral message', () => {
+    let messageWithEphemeralPayload: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithEphemeralPayload = {
+        method: 'personal_sign',
+        params: [Authenticator.getEphemeralMessage('0x1234567890123456789012345678901234567890', new Date('2100-01-01T00:00:00.000Z'))]
+      }
+    })
+
+    it('should throw an error indicating that signing an ephemeral message is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithEphemeralPayload)).toThrow('Signing a Decentraland ephemeral message is not allowed')
+    })
+  })
+
+  describe('and the method is personal_sign for a hex encoded Decentraland ephemeral message', () => {
+    let messageWithHexEphemeralPayload: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      const ephemeralMessage = Authenticator.getEphemeralMessage(
+        '0x1234567890123456789012345678901234567890',
+        new Date('2100-01-01T00:00:00.000Z')
+      )
+      messageWithHexEphemeralPayload = {
+        method: 'personal_sign',
+        params: [`0x${Buffer.from(ephemeralMessage, 'utf8').toString('hex')}`]
+      }
+    })
+
+    it('should throw an error indicating that signing an ephemeral message is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithHexEphemeralPayload)).toThrow(
+        'Signing a Decentraland ephemeral message is not allowed'
+      )
+    })
+  })
+
+  describe('and the method is eth_sign for a Decentraland ephemeral message', () => {
+    let messageWithEphemeralPayload: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithEphemeralPayload = {
+        method: 'eth_sign',
+        params: [
+          '0x1234567890123456789012345678901234567890',
+          Authenticator.getEphemeralMessage('0x1234567890123456789012345678901234567890', new Date('2100-01-01T00:00:00.000Z'))
+        ]
+      }
+    })
+
+    it('should throw an error indicating that signing an ephemeral message is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithEphemeralPayload)).toThrow('Signing a Decentraland ephemeral message is not allowed')
+    })
+  })
+
+  describe('and the method is personal_sign for an ephemeral message with a disguised first line', () => {
+    let messageWithDisguisedEphemeralPayload: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithDisguisedEphemeralPayload = {
+        method: 'personal_sign',
+        params: [
+          'Totally harmless greeting\nEphemeral address: 0x1234567890123456789012345678901234567890\nExpiration: 2100-01-01T00:00:00.000Z'
+        ]
+      }
+    })
+
+    it('should throw an error indicating that signing an ephemeral message is not allowed', () => {
+      expect(() => validateRequestMessage(messageWithDisguisedEphemeralPayload)).toThrow(
+        'Signing a Decentraland ephemeral message is not allowed'
+      )
+    })
+  })
+
+  describe('and the method is a non signing wallet method', () => {
+    let messageWithNonSigningMethod: RequestMessage
+
+    beforeEach(() => {
+      messageWithNonSigningMethod = { method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1' }] }
+    })
+
+    it('should return the validated message', () => {
+      expect(validateRequestMessage(messageWithNonSigningMethod)).toEqual(messageWithNonSigningMethod)
+    })
+  })
+})
+
+describe('when checking whether a method is disallowed', () => {
+  describe('and the method is dcl_personal_sign', () => {
+    let disallowedMethod: string
+
+    beforeEach(() => {
+      disallowedMethod = 'dcl_personal_sign'
+    })
+
+    it('should return true', () => {
+      expect(isDisallowedMethod(disallowedMethod)).toBe(true)
+    })
+  })
+
+  describe('and the method is personal_sign', () => {
+    let allowedMethod: string
+
+    beforeEach(() => {
+      allowedMethod = 'personal_sign'
+    })
+
+    it('should return false', () => {
+      expect(isDisallowedMethod(allowedMethod)).toBe(false)
+    })
+  })
+})
+
+describe('when checking whether a value is a Decentraland ephemeral message', () => {
+  describe('and the value is an ephemeral message', () => {
+    let ephemeralMessage: string
+
+    beforeEach(() => {
+      ephemeralMessage = Authenticator.getEphemeralMessage(
+        '0x1234567890123456789012345678901234567890',
+        new Date('2100-01-01T00:00:00.000Z')
+      )
+    })
+
+    it('should return true', () => {
+      expect(isEphemeralMessage(ephemeralMessage)).toBe(true)
+    })
+  })
+
+  describe('and the value is an expired ephemeral message', () => {
+    let expiredEphemeralMessage: string
+
+    beforeEach(() => {
+      expiredEphemeralMessage = Authenticator.getEphemeralMessage(
+        '0x1234567890123456789012345678901234567890',
+        new Date('2020-01-01T00:00:00.000Z')
+      )
+    })
+
+    it('should return true', () => {
+      expect(isEphemeralMessage(expiredEphemeralMessage)).toBe(true)
+    })
+  })
+
+  describe('and the value is an ordinary message', () => {
+    let ordinaryMessage: string
+
+    beforeEach(() => {
+      ordinaryMessage = 'Please sign to confirm your order'
+    })
+
+    it('should return false', () => {
+      expect(isEphemeralMessage(ordinaryMessage)).toBe(false)
+    })
+  })
+
+  describe('and the value is hex encoded transaction data', () => {
+    let transactionData: string
+
+    beforeEach(() => {
+      transactionData = '0xa9059cbb0000000000000000000000001234567890123456789012345678901234567890'
+    })
+
+    it('should return false', () => {
+      expect(isEphemeralMessage(transactionData)).toBe(false)
     })
   })
 })

--- a/test/unit/validations.spec.ts
+++ b/test/unit/validations.spec.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
+import { AuthChain, AuthLinkType } from '@dcl/schemas'
 import { isEphemeralMessage } from '../../src/logic/auth-chain'
 import { MAX_METHOD_LENGTH, MAX_PARAMS_ITEMS, MAX_ERROR_MESSAGE_LENGTH, MAX_REQUEST_ID_LENGTH } from '../../src/ports/server/constants'
 import {
@@ -8,7 +9,8 @@ import {
   OutcomeMessage,
   RequestValidationMessage,
   HttpOutcomeMessage,
-  IdentityRequest
+  IdentityRequest,
+  ValidatedRequestMessage
 } from '../../src/ports/server/types'
 import {
   validateRequestMessage,
@@ -22,14 +24,24 @@ import {
 } from '../../src/ports/server/validations'
 import { generateRandomIdentityId, createTestIdentity } from '../utils/test-identity'
 
+/**
+ * A well-shaped auth chain. `validateRequestMessage` only requires the chain to be present and to
+ * match the schema — signatures are verified separately by `validateAuthChain` — so a single SIGNER
+ * link is enough to exercise these cases.
+ */
+function createStubAuthChain(): AuthChain {
+  return [{ type: AuthLinkType.SIGNER, payload: '0x1234567890123456789012345678901234567890', signature: '' }]
+}
+
 describe('when validating request messages', () => {
   describe('and the message is valid', () => {
-    let validRequestMessage: RequestMessage
+    let validRequestMessage: ValidatedRequestMessage
 
     beforeEach(() => {
       validRequestMessage = {
         method: 'eth_sendTransaction',
-        params: [{ from: '0x123', to: '0x456', value: '0x1' }]
+        params: [{ from: '0x123', to: '0x456', value: '0x1' }],
+        authChain: createStubAuthChain()
       }
     })
 
@@ -63,10 +75,10 @@ describe('when validating request messages', () => {
   })
 
   describe('and the method is at max length', () => {
-    let messageWithMaxMethod: { method: string; params: unknown[] }
+    let messageWithMaxMethod: { method: string; params: unknown[]; authChain: AuthChain }
 
     beforeEach(() => {
-      messageWithMaxMethod = { method: 'a'.repeat(MAX_METHOD_LENGTH), params: [] }
+      messageWithMaxMethod = { method: 'a'.repeat(MAX_METHOD_LENGTH), params: [], authChain: createStubAuthChain() }
     })
 
     it('should return a message whose method is at the max length', () => {
@@ -87,10 +99,14 @@ describe('when validating request messages', () => {
   })
 
   describe('and the params array is at max items', () => {
-    let messageWithMaxParams: { method: string; params: unknown[] }
+    let messageWithMaxParams: { method: string; params: unknown[]; authChain: AuthChain }
 
     beforeEach(() => {
-      messageWithMaxParams = { method: 'eth_call', params: Array(MAX_PARAMS_ITEMS).fill({ data: 'test' }) }
+      messageWithMaxParams = {
+        method: 'eth_call',
+        params: Array(MAX_PARAMS_ITEMS).fill({ data: 'test' }),
+        authChain: createStubAuthChain()
+      }
     })
 
     it('should return a message with the max number of params', () => {
@@ -123,12 +139,13 @@ describe('when validating request messages', () => {
   })
 
   describe('and the method is personal_sign for an ordinary message', () => {
-    let messageWithPersonalSign: RequestMessage
+    let messageWithPersonalSign: ValidatedRequestMessage
 
     beforeEach(() => {
       messageWithPersonalSign = {
         method: 'personal_sign',
-        params: ['Please sign to confirm your order', '0x1234567890123456789012345678901234567890']
+        params: ['Please sign to confirm your order', '0x1234567890123456789012345678901234567890'],
+        authChain: createStubAuthChain()
       }
     })
 
@@ -211,14 +228,42 @@ describe('when validating request messages', () => {
   })
 
   describe('and the method is a non signing wallet method', () => {
-    let messageWithNonSigningMethod: RequestMessage
+    let messageWithNonSigningMethod: ValidatedRequestMessage
 
     beforeEach(() => {
-      messageWithNonSigningMethod = { method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1' }] }
+      messageWithNonSigningMethod = {
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }],
+        authChain: createStubAuthChain()
+      }
     })
 
     it('should return the validated message', () => {
       expect(validateRequestMessage(messageWithNonSigningMethod)).toEqual(messageWithNonSigningMethod)
+    })
+  })
+
+  describe('and the auth chain is not provided', () => {
+    let messageWithoutAuthChain: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      messageWithoutAuthChain = { method: 'eth_sendTransaction', params: [{ from: '0x123', to: '0x456' }] }
+    })
+
+    it('should throw an error indicating that the auth chain is required', () => {
+      expect(() => validateRequestMessage(messageWithoutAuthChain)).toThrow('Auth chain is required')
+    })
+  })
+
+  describe('and the auth chain is not provided for a disallowed method', () => {
+    let disallowedMessageWithoutAuthChain: { method: string; params: unknown[] }
+
+    beforeEach(() => {
+      disallowedMessageWithoutAuthChain = { method: 'dcl_personal_sign', params: [] }
+    })
+
+    it('should throw the disallowed method error rather than the auth chain one', () => {
+      expect(() => validateRequestMessage(disallowedMessageWithoutAuthChain)).toThrow('The dcl_personal_sign method is not allowed')
     })
   })
 })


### PR DESCRIPTION
## Why

`dcl_personal_sign` drove the desktop sign-in flow: a request was created with **no auth chain at all**, so the auth dapp could sign an ephemeral message and mint an auth identity from the result. That flow is no longer supported, and we should stop allowing it.

Removing the special case alone would not actually stop the process. The ephemeral message is what mints the identity, not the method name — passing the same payload to `personal_sign` or `eth_sign` reproduces the flow exactly. So this PR removes the flow *and* blocks the payload that reproduces it.

## What changed

**The flow is gone.** Removed the `METHOD_DCL_PERSONAL_SIGN` constant, both special-case branches (HTTP `POST /requests` and the socket `REQUEST` handler), and the separate `DCL_PERSONAL_SIGN_REQUEST_EXPIRATION_IN_SECONDS` knob along with its plumbing through `SocketServerOptions` / `RequestExpirationOptions`. An auth chain is now required on **every** request — previously `dcl_personal_sign` requests were an unauthenticated write path into request storage — so `sender` is always derived from it rather than being optionally absent. All requests now use `REQUEST_EXPIRATION_IN_SECONDS` (300s); the 600s sign-in expiration is gone.

**Two checks added** to `validateRequestMessage`, the validator both entry points already share, so the socket and HTTP paths cannot drift apart on what they accept:

| Rejected | Error |
| --- | --- |
| `dcl_personal_sign`, any casing | `The dcl_personal_sign method is not allowed` |
| Any string param that is a Decentraland ephemeral message | `Signing a Decentraland ephemeral message is not allowed` |

**Ordinary signing is unaffected** — `personal_sign`, `eth_sign` and `eth_signTypedData*` are all still accepted for messages that are not ephemeral messages, as are `eth_sendTransaction`, `eth_call` and the `wallet_*` methods.

## Two details that decide whether this holds

**Detection delegates to `@dcl/crypto`'s own `parseEmphemeralPayload`** — the same parser `ECDSA_PERSONAL_EPHEMERAL_VALIDATOR` uses to validate an auth link. This matters more than it looks: that parser **ignores the first line**, requiring only the `Ephemeral address:` and `Expiration:` lines. Matching the `Decentraland Login` greeting would therefore have been trivially bypassable, since any greeting still yields a usable ephemeral link. Sharing the parser also makes the guard self-consistent — a payload crafted to evade detection (unicode homoglyphs, leading whitespace, `\r` insertion) also fails auth-link validation, so the resulting signature is useless.

**Hex payloads are decoded before checking.** `personal_sign` takes its message hex-encoded as often as plain text, so `0x4465636...` would otherwise have walked straight through.

## Rollout

Safe for in-flight requests. `sender` is deliberately left optional on `StorageRequest`: requests created by the old code sit in Redis without one for up to 10 minutes, and the recover/outcome handlers read neither `method` nor `sender`, so they keep resolving through the deploy. Deploy environments that still set the dropped env var are unaffected — it is simply no longer read.

## Testing

- **229 unit tests** pass. `test/unit/validations.spec.ts` covers both rejections, the hex-encoded and disguised-greeting bypass attempts, and — importantly — that an ordinary `personal_sign` still validates.
- **113 integration tests** pass. Both suites used `dcl_personal_sign` as "the method that needs no auth chain", so every request site now builds a real auth chain via a `useTestIdentity()` helper matching the existing `connectClients` idiom; recover assertions gained the now-always-present `sender`. Each entry point got the same three new cases, including a positive test that a normal `personal_sign` request is created.
- Lint, prettier and both typecheck projects clean.

## Reviewer notes

- The guard runs at request **creation**. The auth dapp is what ultimately presents payloads to the wallet, so if it can be reached by any other path it needs the equivalent check — only this service is touched here.
- `params.some(p => typeof p === 'string' && …)` inspects only top-level string params. No standard signing method turns a nested element into an EIP-191 signature over that text, so there is no exploit path, but it is a place to tighten if a future method takes its message inside a structure.
- `authChain` is now marked `required` in the OpenAPI `RequestMessage` schema to reflect the real contract. The Ajv schema still leaves it optional so the handler can return the clearer `Auth chain is required` rather than an Ajv error blob.
- One incidental one-line prettier whitespace fix in an unrelated README section, applied by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
