### PR TITLE
fix(auth): upgrade crypto middleware validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@dcl/core-commons": "^0.10.1",
         "@dcl/crypto": "^3.7.0",
-        "@dcl/crypto-middleware": "^4.1.1",
+        "@dcl/crypto-middleware": "^5.1.0",
         "@dcl/features-component": "^1.0.2",
         "@dcl/fetch-component": "^1.1.1",
         "@dcl/http-commons": "^2.0.0",
@@ -665,9 +665,9 @@
       }
     },
     "node_modules/@dcl/crypto-middleware": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.1.tgz",
-      "integrity": "sha512-wNo3D00SyZKoxy3THQj+EMWWatU9F2VTPwqTIVWZj3JlnaKRScNpLOsrHVPETN9FYtTIlJqqhjlUWsjoUGVisw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz",
+      "integrity": "sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/core-commons": "^0.10.0",
@@ -675,18 +675,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "express": "^4.0.0 || ^5.0.0",
-        "koa": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "express": {
-          "optional": true
-        },
-        "koa": {
-          "optional": true
-        }
       }
     },
     "node_modules/@dcl/crypto/node_modules/@noble/curves": {
@@ -1036,6 +1024,32 @@
       "peerDependencies": {
         "@types/jest": ">=29",
         "jest": ">=29"
+      }
+    },
+    "node_modules/@dcl/test-helpers/node_modules/@dcl/crypto-middleware": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.1.tgz",
+      "integrity": "sha512-wNo3D00SyZKoxy3THQj+EMWWatU9F2VTPwqTIVWZj3JlnaKRScNpLOsrHVPETN9FYtTIlJqqhjlUWsjoUGVisw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/core-commons": "^0.10.0",
+        "@dcl/crypto": "3.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0",
+        "koa": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "koa": {
+          "optional": true
+        }
       }
     },
     "node_modules/@dcl/tracer-component": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.7.0",
-    "@dcl/crypto-middleware": "^4.1.1",
+    "@dcl/crypto-middleware": "^5.1.0",
     "@dcl/features-component": "^1.0.2",
     "@dcl/fetch-component": "^1.1.1",
     "@dcl/http-commons": "^2.0.0",

--- a/test/integration/canonical-signer.spec.ts
+++ b/test/integration/canonical-signer.spec.ts
@@ -1,0 +1,108 @@
+import { AuthIdentity } from '@dcl/crypto'
+import { AUTH_METADATA_HEADER } from '@dcl/crypto-middleware'
+import { signedFetchFactory } from 'decentraland-crypto-fetch'
+import { test } from '../components'
+import { createSignedFetchRequest } from '../utils/signed-request'
+import { createTestIdentity } from '../utils/test-identity'
+
+const SIGNED_METADATA = { signer: 'decentraland-kernel-scene' }
+const DELIVERED_METADATA = JSON.stringify({ signer: 'Decentraland-Kernel-Scene' })
+
+/**
+ * Delivers a metadata header that differs from the one `signedFetch` actually signed. The canonical
+ * payload is lowercased before signing, so a value differing only in case shares the signature —
+ * the request arrives genuinely authentic while reading differently to any case-sensitive
+ * comparison downstream. This is the attack, not a mock: nothing here weakens the signature.
+ */
+function createTamperingFetch(deliveredMetadata: string): typeof fetch {
+  return (async (input: Request): Promise<Response> => {
+    const headers: Record<string, string> = {}
+    input.headers.forEach((value, key) => {
+      headers[key] = value
+    })
+    headers[AUTH_METADATA_HEADER] = deliveredMetadata
+    const body = input.method === 'GET' || input.method === 'HEAD' ? undefined : await input.text()
+
+    return fetch(input.url, { method: input.method, headers, body })
+  }) as unknown as typeof fetch
+}
+
+test('when a request carries a scene signer', args => {
+  let baseUrl: string
+  let identity: AuthIdentity
+
+  beforeEach(async () => {
+    const port = await args.components.config.requireString('HTTP_SERVER_PORT')
+    baseUrl = `http://localhost:${port}`
+    identity = await createTestIdentity()
+  })
+
+  describe('and the canonical signer was signed but a mixed-case spelling is delivered', () => {
+    let response: Response
+
+    beforeEach(async () => {
+      const tamperingFetch = signedFetchFactory({ fetch: createTamperingFetch(DELIVERED_METADATA) })
+
+      response = await tamperingFetch(`${baseUrl}/identities`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identity }),
+        identity,
+        metadata: SIGNED_METADATA
+      })
+    })
+
+    it('should reject the request rather than let it past the scene gate', async () => {
+      const responseBody = await response.json()
+
+      // Without this guard the mixed-case spelling fails the strict `!== 'decentraland-kernel-scene'`
+      // check in routes.ts, so the scene request is read as a directly user-signed one and served.
+      expect(response.status).toBe(400)
+      // The raw metadata is echoed back truncated at 64 characters, so match the prefix.
+      expect(responseBody.error).toMatch(/^Invalid chain metadata: /)
+    })
+  })
+
+  describe('and the canonical signer is delivered exactly as signed', () => {
+    let response: Response
+
+    beforeEach(async () => {
+      response = await createSignedFetchRequest(baseUrl, {
+        method: 'POST',
+        path: '/identities',
+        body: { identity },
+        identity,
+        metadata: SIGNED_METADATA
+      })
+    })
+
+    it('should reject it as a scene request', async () => {
+      const responseBody = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(responseBody.error).toMatch(/^Invalid metadata content: /)
+    })
+  })
+
+  describe('and the request carries no signer at all', () => {
+    let response: Response
+
+    beforeEach(async () => {
+      response = await createSignedFetchRequest(baseUrl, {
+        method: 'POST',
+        path: '/identities',
+        body: { identity },
+        identity
+      })
+    })
+
+    it('should authenticate normally and reach the handler', async () => {
+      const responseBody = await response.json()
+
+      // Ordinary user traffic must be untouched by the guard: this gets all the way to the
+      // handler, which stores the identity and returns its id.
+      expect(response.status).toBe(201)
+      expect(responseBody).toHaveProperty('identityId')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- upgrade `@dcl/crypto-middleware` from v4.1.1 to v5.1.0
- add an integration regression test for canonical signed-fetch metadata and the kernel-scene signer gate

## Validation

- [x] `npm run build`
- [x] `npm run check:prettier`
- [x] `npm run lint`
- [x] `npm test -- --runInBand` (13 suites, 231 tests)
- [x] `npm run test:integration` (7 suites, 116 tests)
- [x] canonical-signer integration test (3 tests)

The runtime middleware resolves to v5.1.0 and includes the canonical `trim()` validation guard. The nested v4 copy remains isolated under `@dcl/test-helpers` for tests only.
